### PR TITLE
fix Core Makefile

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -3,9 +3,9 @@ libcore.a:
 	@gcc \
 	-DDEBUG \
 	-c *.c -I . \
-	-I./../../deps/libz/linux-debian-x64/include \
+	-I./../deps/libz/linux-debian-x64/include \
 	-I./../../deps/lpng
-	@ar rcs libcore.a *.o /deps/libz/linux-debian-x64/libs/libz.a
+	@ar rcs libcore.a *.o ./../deps/libz/linux-debian-x64/libs/libz.a
 
 clean:
 	@rm -rf *.o


### PR DESCRIPTION
with this, you can now do

```shell
$ cd ./core
$ make
```

and get a compiled `libcore.a` static lib :)