### PR TITLE
CLI: add command to count blocks

### DIFF
--- a/cli/blocks.cpp
+++ b/cli/blocks.cpp
@@ -1,0 +1,80 @@
+//
+//  combine.cpp
+//  cli
+//
+//  Created by Gaetan de Villele on 13/10/2022.
+//
+
+#include "combine.hpp"
+
+// C++
+#include <iostream>
+#include <vector>
+
+// Cubzh Core
+#include "shape.h"
+#include "stream.h"
+#include "color_atlas.h"
+#include "magicavoxel.h"
+#include "serialization.h"
+
+bool count_blocks(cxxopts::ParseResult parseResult, std::string& err) {
+    
+    // validation
+
+    if (parseResult.count("input") <= 0) {
+        err.assign("no input files");
+        return false;
+    }
+
+    if (parseResult.count("input") != 1) {
+        err.assign("only 1 input file is allowed");
+        return false;
+    }
+
+    // processing
+
+    std::string input_path = parseResult["input"].as<std::vector<std::string>>()[0];
+    
+    FILE *fd = fopen(input_path.c_str(), "rw");
+    if (fd == nullptr) {
+        err = std::string("can't open ") + input_path;
+        return false;
+    }
+    
+    ColorAtlas *colorAtlas = color_atlas_new();
+    Stream *s = stream_new_file_read(fd);
+    
+    LoadShapeSettings shapeSettings;
+    shapeSettings.octree = true;
+    shapeSettings.lighting = false;
+    shapeSettings.isMutable = false;
+    
+    DoublyLinkedList *assets = serialization_load_assets(s, "", AssetType_Shape, colorAtlas, &shapeSettings);
+    if (assets == NULL) {
+        fclose(fd);
+        color_atlas_free(colorAtlas);
+        err.assign("can't load assets");
+        return false;
+    }
+    
+    size_t n = 0;
+    
+    DoublyLinkedListNode *node = doubly_linked_list_first(assets);
+    while (node != NULL) {
+        Asset *r = (Asset *)doubly_linked_list_node_pointer(node);
+        if (r->type == AssetType_Shape) {
+            n += shape_get_nb_blocks((Shape *)r->ptr);
+            shape_free((Shape *)r->ptr);
+        }
+        node = doubly_linked_list_node_next(node);
+    }
+    doubly_linked_list_flush(assets, free);
+    doubly_linked_list_free(assets);
+    
+    color_atlas_free(colorAtlas);
+    
+    std::cout << n << std::endl;
+    
+    return true;
+}

--- a/cli/blocks.hpp
+++ b/cli/blocks.hpp
@@ -1,0 +1,18 @@
+//
+//  combine.hpp
+//  cli
+//
+//  Created by Gaetan de Villele on 13/10/2022.
+//
+
+#pragma once
+
+// C++
+#include <string>
+
+// cxxopts
+#include <cxxopts.hpp>
+
+/// Returns true on success, false otherwise.
+/// When an error occured, the `err` argument is filled with an error message.
+bool count_blocks(cxxopts::ParseResult parseResult, std::string& err);

--- a/cli/combine.cpp
+++ b/cli/combine.cpp
@@ -37,7 +37,7 @@ bool command_combine(cxxopts::ParseResult parseResult, std::string& err) {
     // processing
 
     std::vector<std::string> input_paths = parseResult["input"].as<std::vector<std::string>>();
-    std::string output_path = parseResult["output"].as<std::string>();;
+    std::string output_path = parseResult["output"].as<std::string>();
 
     std::cout << "* Combining voxel files..." << std::endl;
     for (std::string input_path : input_paths) {

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -13,6 +13,7 @@
 
 // cli
 #include "combine.hpp"
+#include "blocks.hpp"
 
 int main(int argc, const char * argv[]) {
 
@@ -41,6 +42,8 @@ int main(int argc, const char * argv[]) {
 
     if (command == "combine") {
         success = command_combine(result, err);
+    } else if (command == "blocks") {
+        success = count_blocks(result, err);
     } else {
         err = "command not supported.";
     }

--- a/cli/xcode/cli.xcodeproj/project.pbxproj
+++ b/cli/xcode/cli.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10F28337297AA811004AA9F2 /* blocks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10F28335297AA811004AA9F2 /* blocks.cpp */; };
 		850CDB8028F854C000D81015 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 850CDB7F28F854C000D81015 /* main.cpp */; };
 		85AA097928F8649B00801372 /* combine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85AA097728F8649B00801372 /* combine.cpp */; };
-		85AA09D728F86CE900801372 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 85AA097B28F86CE800801372 /* Makefile */; };
 		85AA09D828F86CE900801372 /* rtree.c in Sources */ = {isa = PBXBuildFile; fileRef = 85AA097D28F86CE800801372 /* rtree.c */; };
 		85AA09D928F86CE900801372 /* scene.c in Sources */ = {isa = PBXBuildFile; fileRef = 85AA097E28F86CE800801372 /* scene.c */; };
 		85AA09DA28F86CE900801372 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 85AA097F28F86CE800801372 /* utils.c */; };
@@ -70,12 +70,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		10F28335297AA811004AA9F2 /* blocks.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = blocks.cpp; path = ../blocks.cpp; sourceTree = "<group>"; };
+		10F28336297AA811004AA9F2 /* blocks.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = blocks.hpp; path = ../blocks.hpp; sourceTree = "<group>"; };
 		850CDB7428F853ED00D81015 /* cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cli; sourceTree = BUILT_PRODUCTS_DIR; };
 		850CDB7F28F854C000D81015 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = ../main.cpp; sourceTree = "<group>"; };
 		850CDB8228F85F7600D81015 /* cxxopts.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = cxxopts.hpp; path = ../../deps/cxxopts/darwin/include/cxxopts.hpp; sourceTree = "<group>"; };
 		85AA097728F8649B00801372 /* combine.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = combine.cpp; path = ../combine.cpp; sourceTree = "<group>"; };
 		85AA097828F8649B00801372 /* combine.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = combine.hpp; path = ../combine.hpp; sourceTree = "<group>"; };
-		85AA097B28F86CE800801372 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; name = Makefile; path = ../../core/Makefile; sourceTree = "<group>"; };
 		85AA097C28F86CE800801372 /* rigidBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rigidBody.h; path = ../../core/rigidBody.h; sourceTree = "<group>"; };
 		85AA097D28F86CE800801372 /* rtree.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rtree.c; path = ../../core/rtree.c; sourceTree = "<group>"; };
 		85AA097E28F86CE800801372 /* scene.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scene.c; path = ../../core/scene.c; sourceTree = "<group>"; };
@@ -203,6 +204,8 @@
 			children = (
 				85AA097728F8649B00801372 /* combine.cpp */,
 				85AA097828F8649B00801372 /* combine.hpp */,
+				10F28335297AA811004AA9F2 /* blocks.cpp */,
+				10F28336297AA811004AA9F2 /* blocks.hpp */,
 				850CDB7F28F854C000D81015 /* main.cpp */,
 			);
 			name = cli;
@@ -274,7 +277,6 @@
 				85AA099E28F86CE800801372 /* int3.h */,
 				85AA09D028F86CE900801372 /* magicavoxel.c */,
 				85AA09D628F86CE900801372 /* magicavoxel.h */,
-				85AA097B28F86CE800801372 /* Makefile */,
 				85AA09A628F86CE800801372 /* map_string_float3.c */,
 				85AA099328F86CE800801372 /* map_string_float3.h */,
 				85AA098428F86CE800801372 /* matrix4x4.c */,
@@ -378,7 +380,6 @@
 				85AA09EA28F86CE900801372 /* ray.c in Sources */,
 				85AA09DF28F86CE900801372 /* color_atlas.c in Sources */,
 				85AA0A0028F86CE900801372 /* color_palette.c in Sources */,
-				85AA09D728F86CE900801372 /* Makefile in Sources */,
 				85AA09D928F86CE900801372 /* scene.c in Sources */,
 				850CDB8028F854C000D81015 /* main.cpp in Sources */,
 				85AA09DA28F86CE900801372 /* utils.c in Sources */,
@@ -416,6 +417,7 @@
 				85AA09DB28F86CE900801372 /* filo_list_float3.c in Sources */,
 				85AA09F528F86CE900801372 /* octree.c in Sources */,
 				85AA09F228F86CE900801372 /* serialization_v5.c in Sources */,
+				10F28337297AA811004AA9F2 /* blocks.cpp in Sources */,
 				85AA0A0228F86CE900801372 /* doubly_linked_list_uint8.c in Sources */,
 				85AA09E328F86CE900801372 /* stream.c in Sources */,
 				85AA09FF28F86CE900801372 /* easings.c in Sources */,

--- a/cli/xcode/cli.xcodeproj/xcshareddata/xcschemes/cli.xcscheme
+++ b/cli/xcode/cli.xcodeproj/xcshareddata/xcschemes/cli.xcscheme
@@ -53,8 +53,12 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "combine -i /Users/aduermael/Desktop/tmp/head.vox -i /Users/aduermael/Desktop/tmp/hair.vox -o  /Users/aduermael/Desktop/tmp/combined.vox"
+            argument = "blocks -i  /Users/aduermael/Desktop/ld52_arena.3zh"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "combine -i /Users/aduermael/Desktop/tmp/head.vox -i /Users/aduermael/Desktop/tmp/hair.vox -o  /Users/aduermael/Desktop/tmp/combined.vox"
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/core/scene.h
+++ b/core/scene.h
@@ -110,7 +110,7 @@ typedef struct {
 
     char pad[1];
 } CastResult;
-CastResult scene_cast_result_default();
+CastResult scene_cast_result_default(void);
 
 CastHitType scene_cast_ray(Scene *sc,
                            const Ray *worldRay,


### PR DESCRIPTION
Adds a command to count blocks. 
⚠️ only support `.3zh` input files, we should add support for `.vox`. 