### PR TITLE
docs: update Shape & MutableShape constructors

### DIFF
--- a/lua/docs/content/page.tmpl
+++ b/lua/docs/content/page.tmpl
@@ -155,16 +155,38 @@
 						<a id="constructor-{{ $i }}"></a>
 						<div class="object-element-tbl">
 							<div class="object-element-header">
-								<a href="#constructor-{{ $i }}"><span class="name">{{ $type }}</span></a> ( <!--
-								-->{{ range $index, $element := .Arguments }}<!--
-								-->{{if $index}}, {{end}}<!--
-								-->{{ $route := GetTypeRoute .Type }}<!--
-								-->{{ if $route }}<a href="{{ $route }}" class="type">{{ else }}<span class="type">{{ end }}<!--
-								-->{{ .Type }}<!--
-								-->{{ if $route }}</a>{{ else }}</span>{{ end }}<!--
-								--> {{ .Name }}<!--
-								-->{{ if .Optional }} <span class="optional">optional</span>{{ end }}<!--
-								-->{{ end }} )
+									{{ if .ArgumentSets}}<!--
+										-->{{ range $index, $arguments := .ArgumentSets }}<!--
+											--><div class="set-of-arguments"><!--
+												-->{{ if $index }}<span class="variation">{{ end}}<!--
+												--><a href="#constructor-{{ $i }}"><span class="name">{{ $type }}</span></a><!--
+												-->{{ if $index }}</span>{{ end}} ( <!--
+												-->{{ range $index, $element := $arguments }}<!--
+												-->{{if $index}}, {{end}}<!--
+													-->{{ $route := GetTypeRoute .Type }}<!--
+													-->{{ if $route }}<a href="{{ $route }}" class="type">{{ else }}<span class="type">{{ end }}<!--
+													-->{{ .Type }}<!--
+													-->{{ if $route }}</a>{{ else }}</span>{{ end }}<!--
+														--> {{ .Name }}<!--
+													-->{{ if .Optional }} <span class="optional">optional</span>{{ end }}<!--
+												-->{{ end }} )<!--
+												-->{{if not $index}}<!--
+													-->{{ if $constructor.ComingSoon }} <span class="coming-soon">coming soon</span>{{ end }}<!--
+												-->{{ end }}<!--
+											--></div><!--
+										-->{{ end }}<!--
+								-->{{ else }}<!--
+									--><a href="#constructor-{{ $i }}"><span class="name">{{ $type }}</span></a> ( <!--
+									-->{{ range $index, $element := .Arguments }}<!--
+									-->{{if $index}}, {{end}}<!--
+									-->{{ $route := GetTypeRoute .Type }}<!--
+									-->{{ if $route }}<a href="{{ $route }}" class="type">{{ else }}<span class="type">{{ end }}<!--
+									-->{{ .Type }}<!--
+									-->{{ if $route }}</a>{{ else }}</span>{{ end }}<!--
+									--> {{ .Name }}<!--
+									-->{{ if .Optional }} <span class="optional">optional</span>{{ end }}<!--
+									-->{{ end }} )<!--
+								-->{{ end }}
 							</div>
 							<div class="object-element-row">
 								{{ if .Description }}

--- a/lua/docs/content/reference/mutableshape.yml
+++ b/lua/docs/content/reference/mutableshape.yml
@@ -5,26 +5,48 @@ description: A [MutableShape] is a [Shape] which [Block]s can be modified.
 
 constructors: 
   - description: |
-        Creates a MutableShape which model can be empty, loaded from an imported [Item], or copied from an existing [Shape] or [MutableShape].
-      
-        The optional parameter `loadBakedLight`, by default `false`, determines whether or not the shape should be loaded with baked lighting. If `true`, it will use the baked lighting information saved with the original item, or compute it from scratch if there was none. Any subsequent changes to the shape's blocks will automatically maintain its baked lighting.
+        Creates a [MutableShape] which model can be empty, loaded from an imported [Item] (see [Items]), or copied from an existing [Shape] or [MutableShape].
+
+        The optional [table] parameter can be used to override default configuration:
+        `{includeChildren = false, bakedLight = false}`.
+
+        `bakedLight` (false by default) determines whether or not the shape should be loaded with baked lighting.  If `true`, it will use the baked lighting information saved with the original item, or compute it from scratch if there was none. Any subsequent changes to the shape's blocks will automatically maintain its baked lighting.
+
+        When copying a [Shape], `includeChildren` (false by default) determines if children should be copied as well.
     argument-sets:
       -
-
+        - name: "config"
+          type: "table"
+          optional: true
       -
         - name: "item"
           type: "Item"
-        - name: "loadBakedLight"
-          type: "boolean"
+        - name: "config"
+          type: "table"
           optional: true
       -
         - name: "copiedShape"
           type: "Shape"
+        - name: "config"
+          type: "table"
+          optional: true
       -
         - name: "copiedMutableShape"
           type: "MutableShape"
+        - name: "config"
+          type: "table"
+          optional: true
+
     samples:
-      - code: local s = MutableShape(R.username.itemName)
+      - code: |
+          -- CREATE SHAPE FROM LOADED ITEM
+          local myMutableShape = MutableShape(Items.someuser.someitem)
+          World:AddChild(myMutableShape) -- adds created MutableShape to the World
+      - 
+        code: |
+          -- COPY SHAPE, INCLUDING CHILDREN:
+          local s2 = MutableShape(s1, {includeChildren = true})
+          World:AddChild(s2) -- adds copied MutableShape to the World
 
 properties:
 

--- a/lua/docs/content/reference/shape.yml
+++ b/lua/docs/content/reference/shape.yml
@@ -14,29 +14,50 @@ description: |
 
 constructors: 
   - description: |
-        Creates a Shape which model can be empty, loaded from an imported [Item], or copied from an existing [Shape] or [MutableShape].
-      
-        The optional parameter `loadBakedLight`, by default `false`, determines whether or not the shape should be loaded with baked lighting. If `true`, it will use the baked lighting information saved with the original item, or compute it from scratch if there was none. Any subsequent changes to the shape's blocks will automatically maintain its baked lighting.
+        Creates a [Shape] which model can be empty, loaded from an imported [Item] (see [Items]), or copied from an existing [Shape] or [MutableShape].
+
+        The optional [table] parameter can be used to override default configuration:
+        `{includeChildren = false, bakedLight = false}`.
+
+        `bakedLight` (false by default) determines whether or not the shape should be loaded with baked lighting.  If `true`, it will use the baked lighting information saved with the original item, or compute it from scratch if there was none. Any subsequent changes to the shape's blocks will automatically maintain its baked lighting.
+
+        When copying a [Shape], `includeChildren` (false by default) determines if children should be copied as well.
+
+    
     argument-sets:
       -
-
+        - name: "config"
+          type: "table"
+          optional: true
       -
         - name: "item"
           type: "Item"
-        - name: "loadBakedLight"
-          type: "boolean"
+        - name: "config"
+          type: "table"
           optional: true
       -
         - name: "copiedShape"
           type: "Shape"
+        - name: "config"
+          type: "table"
+          optional: true
       -
         - name: "copiedMutableShape"
           type: "MutableShape"
+        - name: "config"
+          type: "table"
+          optional: true
+
     samples:
       - code: |
+          -- CREATE SHAPE FROM LOADED ITEM
           local myShape = Shape(Items.someuser.someitem)
-          myShape.Position = { Map.Width * 0.5, Map.Height, Map.Depth * 0.5 }
-          Map:AddChild(myShape) -- adds created shape in the map
+          World:AddChild(myShape) -- adds created Shape to the World
+      - 
+        code: |
+          -- COPY SHAPE, INCLUDING CHILDREN:
+          local s2 = Shape(s1, {includeChildren = true})
+          World:AddChild(s2) -- adds copied Shape to the World
 
 properties:
 


### PR DESCRIPTION
Documenting new optional `config` (table) parameter for both these constructors. 
Default config : 
```lua
{
    includeChildren = false,
    bakedLight = false
}
```