### PR TITLE
make shape_make() thread safe

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -7,9 +7,9 @@
 #include "mutex.h"
 
 void mutex_lock(Mutex *m) {
-    pthread_mutex_lock((pthread_mutex_t*)m);
+    pthread_mutex_lock((pthread_mutex_t *)m);
 }
 
 void mutex_unlock(Mutex *m) {
-    pthread_mutex_unlock((pthread_mutex_t*)m);
+    pthread_mutex_unlock((pthread_mutex_t *)m);
 }

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------
+//  Cubzh Core
+//  mutex.c
+//  Created by Adrien Duermael on April 2, 2023.
+// -------------------------------------------------------------
+
+#include "mutex.h"
+
+void mutex_lock(Mutex *m) {
+    pthread_mutex_lock((pthread_mutex_t*)m);
+}
+
+void mutex_unlock(Mutex *m) {
+    pthread_mutex_unlock((pthread_mutex_t*)m);
+}

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -7,8 +7,8 @@
 #include "mutex.h"
 
 // C
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 // Core
 #include "cclog.h"
@@ -35,7 +35,7 @@ Mutex *mutex_new(void) {
 }
 
 /// Free a Mutex
-void mutex_free(Mutex* const m) {
+void mutex_free(Mutex *const m) {
     if (m == NULL) {
         cclog_error("mutex_free: mutex is NULL");
         return;
@@ -47,9 +47,8 @@ void mutex_free(Mutex* const m) {
     free(m);
 }
 
-void mutex_lock(Mutex * const m) {
+void mutex_lock(Mutex *const m) {
     if (m == NULL) {
-        cclog_error("mutex_lock: mutex is NULL");
         return;
     }
     DWORD waitResult = WaitForSingleObject(*m, INFINITE);
@@ -65,9 +64,8 @@ void mutex_lock(Mutex * const m) {
     }
 }
 
-void mutex_unlock(Mutex * const m) {
+void mutex_unlock(Mutex *const m) {
     if (m == NULL) {
-        cclog_error("mutex_unlock: mutex is NULL");
         return;
     }
     const bool ok = ReleaseMutex(*m);
@@ -95,7 +93,7 @@ Mutex *mutex_new(void) {
     return mtx;
 }
 
-void mutex_free(Mutex * const m) {
+void mutex_free(Mutex *const m) {
     if (m == NULL) {
         cclog_error("mutex_free: mutex is NULL");
         return;
@@ -107,11 +105,17 @@ void mutex_free(Mutex * const m) {
     free(m);
 }
 
-void mutex_lock(Mutex * const m) {
+void mutex_lock(Mutex *const m) {
+    if (m == NULL) {
+        return;
+    }
     pthread_mutex_lock((pthread_mutex_t *)m);
 }
 
-void mutex_unlock(Mutex * const m) {
+void mutex_unlock(Mutex *const m) {
+    if (m == NULL) {
+        return;
+    }
     pthread_mutex_unlock((pthread_mutex_t *)m);
 }
 

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -6,10 +6,113 @@
 
 #include "mutex.h"
 
-void mutex_lock(Mutex *m) {
+// C
+#include <stdlib.h>
+#include <stdbool.h>
+
+// Core
+#include "cclog.h"
+
+#if defined(__VX_PLATFORM_WINDOWS)
+
+/// Alloc a Mutex
+Mutex *mutex_new(void) {
+    Mutex *mtxPtr = (Mutex *)malloc(sizeof(Mutex));
+    if (mtxPtr == NULL) {
+        return NULL;
+    }
+
+    *mtxPtr = CreateMutex(NULL,  // default security attributes
+                          FALSE, // initially not owned
+                          NULL); // unnamed mutex
+
+    if (*mtxPtr == NULL) {
+        cclog_error("mutex_new failed: %d", GetLastError());
+        return NULL;
+    }
+
+    return mtxPtr;
+}
+
+/// Free a Mutex
+void mutex_free(Mutex* const m) {
+    if (m == NULL) {
+        cclog_error("mutex_free: mutex is NULL");
+        return;
+    }
+    const bool ok = CloseHandle(*m);
+    if (ok == false) {
+        cclog_error("mutex_free: failed to close handle");
+    }
+    free(m);
+}
+
+void mutex_lock(Mutex * const m) {
+    if (m == NULL) {
+        cclog_error("mutex_lock: mutex is NULL");
+        return;
+    }
+    DWORD waitResult = WaitForSingleObject(*m, INFINITE);
+    switch (waitResult) {
+        // The thread got ownership of the mutex
+        case WAIT_OBJECT_0:
+            break;
+        // The thread got ownership of an abandoned mutex
+        // The database is in an indeterminate state
+        case WAIT_ABANDONED:
+            cclog_error("mutex_lock: failed to lock");
+            break;
+    }
+}
+
+void mutex_unlock(Mutex * const m) {
+    if (m == NULL) {
+        cclog_error("mutex_unlock: mutex is NULL");
+        return;
+    }
+    const bool ok = ReleaseMutex(*m);
+    if (ok == false) {
+        cclog_error("mutex_unlock: failed to unlock");
+    }
+}
+
+#else // non-Windows platforms
+
+Mutex *mutex_new(void) {
+    Mutex *mtx = (Mutex *)malloc(sizeof(pthread_mutex_t));
+    if (mtx == NULL) {
+        return NULL;
+    }
+
+    const int err = pthread_mutex_init((pthread_mutex_t *)mtx, NULL);
+    if (err != 0) {
+        // failure
+        cclog_error("mutex_new failed: %d", err);
+        free(mtx);
+        return NULL;
+    }
+
+    return mtx;
+}
+
+void mutex_free(Mutex * const m) {
+    if (m == NULL) {
+        cclog_error("mutex_free: mutex is NULL");
+        return;
+    }
+    const int err = pthread_mutex_destroy((pthread_mutex_t *)m);
+    if (err != 0) {
+        cclog_error("mutex_free: failed %d", err);
+    }
+    free(m);
+}
+
+void mutex_lock(Mutex * const m) {
     pthread_mutex_lock((pthread_mutex_t *)m);
 }
 
-void mutex_unlock(Mutex *m) {
+void mutex_unlock(Mutex * const m) {
     pthread_mutex_unlock((pthread_mutex_t *)m);
 }
+
+#endif // defined(__VX_PLATFORM_WINDOWS)

--- a/core/mutex.h
+++ b/core/mutex.h
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------
+//  Cubzh Core
+//  mutex.h
+//  Created by Adrien Duermael on April 2, 2023.
+// -------------------------------------------------------------
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+
+typedef pthread_mutex_t Mutex;
+
+//Mutex* mutex_new(void);
+//void mutex_free(Mutex *m);
+
+void mutex_lock(Mutex *m);
+void mutex_unlock(Mutex *m);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/core/mutex.h
+++ b/core/mutex.h
@@ -14,8 +14,8 @@ extern "C" {
 
 typedef pthread_mutex_t Mutex;
 
-//Mutex* mutex_new(void);
-//void mutex_free(Mutex *m);
+// Mutex* mutex_new(void);
+// void mutex_free(Mutex *m);
 
 void mutex_lock(Mutex *m);
 void mutex_unlock(Mutex *m);

--- a/core/mutex.h
+++ b/core/mutex.h
@@ -10,15 +10,31 @@
 extern "C" {
 #endif
 
+#if defined(__VX_PLATFORM_WINDOWS)
+
+#include <windows.h>
+
+typedef HANDLE Mutex;
+
+#else // non-Windows platforms
+
 #include <pthread.h>
 
 typedef pthread_mutex_t Mutex;
 
-// Mutex* mutex_new(void);
-// void mutex_free(Mutex *m);
+#endif // defined(__VX_PLATFORM_WINDOWS)
 
-void mutex_lock(Mutex *m);
-void mutex_unlock(Mutex *m);
+/// Alloc a Mutex
+Mutex *mutex_new(void);
+
+/// Free a Mutex
+void mutex_free(Mutex * const m);
+
+/// Locks a Mutex
+void mutex_lock(Mutex * const m);
+
+/// Unlocks a Mutex
+void mutex_unlock(Mutex * const m);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/core/mutex.h
+++ b/core/mutex.h
@@ -28,13 +28,13 @@ typedef pthread_mutex_t Mutex;
 Mutex *mutex_new(void);
 
 /// Free a Mutex
-void mutex_free(Mutex * const m);
+void mutex_free(Mutex *const m);
 
 /// Locks a Mutex
-void mutex_lock(Mutex * const m);
+void mutex_lock(Mutex *const m);
 
 /// Unlocks a Mutex
-void mutex_unlock(Mutex * const m);
+void mutex_unlock(Mutex *const m);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/core/shape.c
+++ b/core/shape.c
@@ -3670,24 +3670,24 @@ static bool _shape_add_block(Shape *shape,
 ///
 static ShapeId getValidShapeId(void) {
     ShapeId resultId = 0;
-    mutex_lock(&shapeIDMutex);
+    mutex_lock(shapeIDMutex);
     if (availableShapeIds == NULL || filo_list_uint16_pop(availableShapeIds, &resultId) == false) {
         resultId = nextShapeId;
         nextShapeId += 1;
     }
-    mutex_unlock(&shapeIDMutex);
+    mutex_unlock(shapeIDMutex);
     return resultId;
 }
 
 ///
 static void recycleShapeId(const ShapeId shapeId) {
     // if list is nil, then initialize it
-    mutex_lock(&shapeIDMutex);
+    mutex_lock(shapeIDMutex);
     if (availableShapeIds == NULL) {
         availableShapeIds = filo_list_uint16_new();
     }
     filo_list_uint16_push(availableShapeIds, shapeId);
-    mutex_unlock(&shapeIDMutex);
+    mutex_unlock(shapeIDMutex);
 }
 
 // MARK: - private functions -

--- a/core/shape.c
+++ b/core/shape.c
@@ -141,9 +141,20 @@ struct _Shape {
 // MARK: - static variables -
 //
 // --------------------------------------------------
-static Mutex shapeIDMutex;
+static Mutex *shapeIDMutex = NULL;
 static ShapeId nextShapeId = 1;
 static FiloListUInt16 *availableShapeIds = NULL;
+
+void shape_initThreadSafety(void) {
+    if (shapeIDMutex != NULL) {
+        cclog_error("shape: thread safety initialized more than once");
+        return;
+    }
+    shapeIDMutex = mutex_new();
+    if (shapeIDMutex == NULL) {
+        cclog_error("shape: failed to init thread safety");
+    }
+}
 
 // MARK: - private functions prototypes -
 

--- a/core/shape.c
+++ b/core/shape.c
@@ -16,11 +16,11 @@
 #include "easings.h"
 #include "filo_list_uint16.h"
 #include "history.h"
+#include "mutex.h"
 #include "rigidBody.h"
 #include "scene.h"
 #include "transaction.h"
 #include "utils.h"
-#include "mutex.h"
 
 #ifdef DEBUG
 #define SHAPE_LIGHTING_DEBUG false

--- a/core/shape.c
+++ b/core/shape.c
@@ -318,7 +318,7 @@ Shape *shape_make(void) {
     s->nbBlocks = 0;
     s->fragmentedVBs = doubly_linked_list_new();
 
-    s->id = getValidShapeId(); // TODO: use mutex - leads to random crashes otherwise
+    s->id = getValidShapeId();
 
     s->maxWidth = s->maxHeight = s->maxDepth = 0;
 

--- a/core/shape.h
+++ b/core/shape.h
@@ -71,6 +71,11 @@ typedef uint8_t ShapeDrawMode;
 #define SHAPE_DRAWMODE_GREY 4
 #define SHAPE_DRAWMODE_GRID 8
 
+/// Initializes mutex for shape thread safety.
+/// This is to be called before using the shape API.
+/// This is optional. If not called, the shape API is not thread-safe.
+void shape_initThreadSafety(void);
+
 // Creates an empty Shape
 Shape *shape_make(void);
 // Creates a copy of the given shape

--- a/core/tests/xcode/unit_tests.xcodeproj/project.pbxproj
+++ b/core/tests/xcode/unit_tests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		85DD9D3E29DC291700C6A5D4 /* mutex.c in Sources */ = {isa = PBXBuildFile; fileRef = 85DD9D3C29DC291700C6A5D4 /* mutex.c */; };
 		85E6383828F7478E001FC12F /* test_list.c in Sources */ = {isa = PBXBuildFile; fileRef = 85E6383528F7478E001FC12F /* test_list.c */; };
 		85E6389428F747A5001FC12F /* magicavoxel.c in Sources */ = {isa = PBXBuildFile; fileRef = 85E6383928F747A4001FC12F /* magicavoxel.c */; };
 		85E6389528F747A5001FC12F /* color_palette.c in Sources */ = {isa = PBXBuildFile; fileRef = 85E6383A28F747A4001FC12F /* color_palette.c */; };
@@ -86,6 +87,8 @@
 		85B30EC929191DF10066E826 /* test_filo_list_uint16.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = test_filo_list_uint16.h; path = ../test_filo_list_uint16.h; sourceTree = "<group>"; };
 		85B30ECA29191DF10066E826 /* test_filo_list_uint32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = test_filo_list_uint32.h; path = ../test_filo_list_uint32.h; sourceTree = "<group>"; };
 		85B78E2828F8084A00AD31DE /* test_transform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = test_transform.h; path = ../test_transform.h; sourceTree = "<group>"; };
+		85DD9D3C29DC291700C6A5D4 /* mutex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mutex.c; path = ../../mutex.c; sourceTree = "<group>"; };
+		85DD9D3D29DC291700C6A5D4 /* mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mutex.h; path = ../../mutex.h; sourceTree = "<group>"; };
 		85E6382428F74695001FC12F /* unit_tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unit_tests; sourceTree = BUILT_PRODUCTS_DIR; };
 		85E6383328F7478E001FC12F /* acutest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = acutest.h; path = ../acutest.h; sourceTree = "<group>"; };
 		85E6383428F7478E001FC12F /* test_shape.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_shape.h; path = ../test_shape.h; sourceTree = "<group>"; };
@@ -276,6 +279,8 @@
 				85E6389128F747A5001FC12F /* map_string_float3.h */,
 				85E6387D28F747A5001FC12F /* matrix4x4.c */,
 				85E6388428F747A5001FC12F /* matrix4x4.h */,
+				85DD9D3C29DC291700C6A5D4 /* mutex.c */,
+				85DD9D3D29DC291700C6A5D4 /* mutex.h */,
 				85E6384728F747A4001FC12F /* octree.c */,
 				85E6388028F747A5001FC12F /* octree.h */,
 				85E6384F28F747A4001FC12F /* quaternion.c */,
@@ -421,6 +426,7 @@
 				85E638A628F747A5001FC12F /* scene.c in Sources */,
 				85E638B628F747A5001FC12F /* serialization_v5.c in Sources */,
 				85E6389A28F747A5001FC12F /* octree.c in Sources */,
+				85DD9D3E29DC291700C6A5D4 /* mutex.c in Sources */,
 				85E6389628F747A5001FC12F /* utils.c in Sources */,
 				85E6389F28F747A5001FC12F /* filo_list_float3.c in Sources */,
 				85E638BA28F747A5001FC12F /* colors.c in Sources */,


### PR DESCRIPTION
Fixes a crash when calling shape_make() in different threads. 
It was necessary to use a mutex in `getValidShapeId()`. 

Also removed an index that needed to be made thread safe too, but realized it wasn't even useful for anything.