### PR TITLE
Docs 0.0.52

### DIFF
--- a/lua/docs/content/reference/animation.yml
+++ b/lua/docs/content/reference/animation.yml
@@ -1,0 +1,125 @@
+keywords: ["cubzh", "game", "mobile", "scripting", "cube", "voxel", "world"]
+type: "Animation"
+description: |
+    An [Animation] is a set of keyframes groups that can be used to animate any object or group of objects, such as animating a character or creating a cutscene.
+
+    Each keyframes group is bound to animating one object, it can be toggled on or off individually to disable part of an animation.
+    For example, a running animation could temporarily toggle off the keyframes group bound to an arm to simultaneously play a wave animation on that arm.
+constructors: 
+  - description: |
+        When created, an [Animation] can be given a name and a set of optional configuration `{ duration, mode, speed, count}`.
+        They are used to initialize the corresponding properties [Duration](#property-duration), [Mode](#property-mode), [Speed](#property-speed) and [Count](#property-count).
+
+    arguments:
+      - name: "name"
+        type: "string"
+        optional: true
+      - name: "config"
+        type: "table"
+        optional: true
+
+properties:
+  - name: "Mode"
+    type: "AnimationMode"
+    description: |
+        An [Animation] can function in three modes,
+        - `AnimationMode.Once` the animation plays one cycle and stops at the end of its duration.
+        - `AnimationMode.Loop` the animation will repeat at the end of each cycle until [Stop](#functions-stop) is called or, if [Count](#property-count) is set, for a specific number of cycles
+        - `AnimationMode.Mirror` the animation will repeat and reverse at the end of each cycle until [Stop](#functions-stop) is called or, if [Count](#property-count) is set, for a specific number of cycles
+    
+  - name: "Duration"
+    type: "number"
+    description: "Duration in seconds of one animation cycle."
+    
+  - name: "Speed"
+    type: "number"
+    description: "Speed of one animation cycle. This is the inverse of [Duration](#property-duration), you can choose to set one or the other."
+
+  - name: "Count"
+    type: "number"
+    description: "Number of cycles to repeat if using [AnimationMode].[Loop](reference/animationmode#property-loop) or [AnimationMode].[Mirror](reference/animationmode#property-mirror)."
+
+  - name: "IsPlaying"
+    type: "boolean"
+    description: "Whether or not the animation is currently playing."
+
+functions:
+  - name: "Play"
+    description: "Starts or resumes the animation."
+  
+  - name: "PlayReverse"
+    description: "Reverse, then starts or resumes the animation."
+
+  - name: "Stop"
+    description: "Stops and resets the animation."
+  
+  - name: "Pause"
+    description: "Pauses the animation."
+  
+  - name: "Tick"
+    description: |
+        Steps the animation one tick. This is typically to be called inside [Client].[Tick](/reference/client#functions-tick) or [Object].[Tick](/reference/object#functions-tick).
+
+        ⚠️ This needs to be called manually currently. In a future version, it may be done automatically.
+  
+  - name: "AddFrameInGroup"
+    description: |
+        Add a keyframe to the group identified by its name, at a given weight, for a transformation of any or all of position, rotation and scale through the last parameter `{ position, rotation, scale }`.
+
+        The weight can be any number, allowing you to organize keyframes relative to each others' weight.
+        Keyframes are then played in order of increasing weight.
+
+        Note that when the animation is played for the first time, keyframes weights are automatically normalized.
+    arguments:
+      - name: "name"
+        type: "string"
+      - name: "weight"
+        type: "number"
+      - name: "transform"
+        type: "table"
+
+  - name: "Bind"
+    description: |
+        Binds a keyframes group identified by its name to the given object. It means whenever this animation is played, that particular group of keyframes will modify the bound object.
+    arguments:
+      - name: "name"
+        type: "string"
+      - name: "target"
+        type: "Object"
+  
+  - name: "Toggle"
+    description: |
+        Toggles a keyframes group identified by its name. Whenever this animation is played, that particular group of keyframes will not be used until toggled back on.
+    arguments:
+      - name: "name"
+        type: "string"
+      - name: "toggle"
+        type: "boolean"
+  
+  - name: "AddOnPlayCallback"
+    description: |
+        Register a function to be called any time the animation is played.
+    arguments:
+      - name: "callback"
+        type: "function"
+
+  - name: "RemoveOnPlayCallback"
+    description: |
+        Unregister a function that was previously registered with [AddOnPlayCallback](#functions-addonplaycallback).
+    arguments:
+      - name: "callback"
+        type: "function"
+  
+  - name: "AddOnStopCallback"
+    description: |
+        Register a function to be called any time the animation is stopped.
+    arguments:
+      - name: "callback"
+        type: "function"
+
+  - name: "RemoveOnStopCallback"
+    description: |
+        Unregister a function that was previously registered with [AddOnStopCallback](#functions-addonplaycallback).
+    arguments:
+      - name: "callback"
+        type: "function"

--- a/lua/docs/content/reference/camera.yml
+++ b/lua/docs/content/reference/camera.yml
@@ -34,7 +34,7 @@ properties:
     - name: "Layers"
       type: "table"
       description: |
-          Integer or table of integers between 1 and 8. Only objects in one of the specified layers are rendered by the camera.
+          Integer or table of integers between 1 and 12. Only objects in one of the specified layers are rendered by the camera.
 
     - name: "Width"
       type: "number"
@@ -275,4 +275,22 @@ functions:
             Map:AddChild(myShape)
             Camera:FitToScreen(myShape, 0.6, false)
             -- the shape now covers 60% of the screen
+    
+    - name: "WorldToScreen"
+      description: |
+          Converts a world point to a screen point through this camera projection.
+      arguments: 
+        - name: "point"
+          type: "Number3"
+      return:
+        - type: "Number2"
+    
+    - name: "ScreenToRay"
+      description: |
+          Converts a screen point into a world [Ray] through this camera projection.
+      arguments: 
+        - name: "point"
+          type: "Number2"
+      return:
+        - type: "Ray"
 

--- a/lua/docs/content/reference/collisiongroups.yml
+++ b/lua/docs/content/reference/collisiongroups.yml
@@ -2,11 +2,11 @@ keywords: ["cubzh", "game", "mobile", "scripting", "cube", "voxel", "world"]
 type: "CollisionGroups"
 
 description: |
-    `CollisionGroups` represents an [array] of collision group numbers.
+    `CollisionGroups` represents an [array] of collision group numbers between `1` and `12`.
 
     Collision groups are used to define how objects in the world collide with each others.
-
-    Group numbers go from `1` to `8`. The [Map] by default is in group `1`, and by default, all [Object]s collide with that group, but that behavior can be changed.
+    
+    By default, the [Map] is in group `1`, [Player]s in group `2` any other objects in group `3` ; players and objects collide with other objects and the map. This behavior can be changed by setting different collision groups.
 
 constructors:
   - description: |

--- a/lua/docs/content/reference/color.yml
+++ b/lua/docs/content/reference/color.yml
@@ -48,3 +48,32 @@ properties:
     - name: "R"
       type: "number"
       description: "Color's red component. (shortcut to [Red](#property-red))"
+
+functions:
+  - name: "Lerp"
+    description: |
+        Sets this `Color` to the linear interpolation between two given `Color` at a given ratio.
+    arguments: 
+      - name: "from"
+        type: "Color"
+      - name: "to"
+        type: "Color"
+      - name: "ratio"
+        type: "number"
+  
+  - name: "Set"
+    description: |
+        Sets this `Color`'s components to the given values.
+    arguments:
+      - name: "r"
+        type: "number"
+      - name: "g"
+        type: "number"
+      - name: "b"
+        type: "number"
+      - name: "a"
+        type: "number"
+        optional: true
+      - name: "light"
+        type: "boolean"
+        optional: true

--- a/lua/docs/content/reference/index.yml
+++ b/lua/docs/content/reference/index.yml
@@ -41,6 +41,7 @@ blocks:
         - "<a href=\"/reference/pointerevent\">PointerEvent</a>"
         - "<a href=\"/reference/quad\">Quad</a>"
         - "<a href=\"/reference/ray\">Ray</a>"
+        - "<a href=\"/reference/rotation\">Rotation</a>"
         - "<a href=\"/reference/screen\">Screen</a>"
         - "<a href=\"/reference/server\">Server</a>"
         - "<a href=\"/reference/shape\">Shape</a>"

--- a/lua/docs/content/reference/index.yml
+++ b/lua/docs/content/reference/index.yml
@@ -5,6 +5,7 @@ blocks:
     - text: "Here's a list of all top level objects in Cubzh scripting environment:"
     - list:
         - "<a href=\"/reference/ambient\">Ambient</a>"
+        - "<a href=\"/reference/animation\">Animation</a>"
         - "<a href=\"/reference/audiolistener\">AudioListener</a>"
         - "<a href=\"/reference/audiosource\">AudioSource</a>"
         - "<a href=\"/reference/block\">Block</a>"

--- a/lua/docs/content/reference/light.yml
+++ b/lua/docs/content/reference/light.yml
@@ -96,4 +96,4 @@ properties:
     - name: "Layers"
       type: "table"
       description: |
-          Integer or table of integers between 1 and 8. The light will affect other objects in matching layers.
+          Integer or table of integers between 1 and 12. The light will affect other objects in matching layers.

--- a/lua/docs/content/reference/number2.yml
+++ b/lua/docs/content/reference/number2.yml
@@ -38,6 +38,16 @@ properties:
           myNumber2.Y = 42
           print(myNumber2.Y)
 
+  - name: "Length"
+    type: "number"
+    description: |
+        Magnitude of the `Number2`.
+
+  - name: "SquaredLength"
+    type: "number"
+    description: |
+      Squared magnitude of the `Number2`.
+
 functions:
   - name: "Copy"
     return: 
@@ -56,3 +66,31 @@ functions:
           local n2 = n1:Copy() -- n2 is a copy of n1, they're not the same Number2
           n2.X = 10
           print(n1.X) -- n1.X is still 1
+  
+  - name: "Normalize"
+    description: |
+      Normalizes the `Number2` so that its magnitude becomes `1.0`.
+  
+  - name: "Lerp"
+    description: |
+        Sets this `Number2` to the linear interpolation between two given `Number2` at a given ratio.
+    arguments: 
+      - name: "from"
+        type: "Number2"
+      - name: "to"
+        type: "Number2"
+      - name: "ratio"
+        type: "number"
+  
+  - name: "Set"
+    description: |
+        Sets this `Number2`'s components to the given values.
+    argument-sets:
+        - 
+          - name: "xy"
+            type: "Number2"
+        - 
+          - name: "x"
+            type: "number"
+          - name: "y"
+            type: "number"

--- a/lua/docs/content/reference/number3.yml
+++ b/lua/docs/content/reference/number3.yml
@@ -143,7 +143,7 @@ functions:
   
   - name: "Angle"
     description: |
-        Returns the angle in radian between this and given `Number3`.
+        Returns the angle in radians between this and given `Number3`.
     argument-sets:
         - 
           - name: "eulerAnglesXYZ"

--- a/lua/docs/content/reference/number3.yml
+++ b/lua/docs/content/reference/number3.yml
@@ -41,7 +41,7 @@ properties:
   - name: "Length"
     type: "number"
     description: |
-        `Number3`'s length.
+        Magnitude of the `Number3`.
         Technically, the square root of the sum of [X](/reference/number3#property-x), [Y](/reference/number3#property-y) & [Z](/reference/number3#property-z) components.
     samples:
       - code: |
@@ -117,24 +117,76 @@ functions:
           local n2 = Number3(1, 0, 0)
           local dot = n1:Dot(n2)
 
-
   - name: "Rotate"
     description: |
-      Rotates the `Number3` using euler angles in parameters (in radians).
-    arguments: 
-      - name: "angles"
-        type: "Number3"
+        Rotates the `Number3` using euler angles in parameters (in radians).
+    argument-sets:
+        - 
+          - name: "eulerAnglesXYZ"
+            type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+        - 
+          - name: "rotation"
+            type: "Rotation"
     samples:
       - code: |
           local someNumber3 = Number3(0,0,1)
           local pi = 3.1415
           someNumber3:Rotate(Number3(0,pi,0))
           -- someNumber3 == Number3(0,0,-1), after a PI rotation around Y axis (180°)
+  
+  - name: "Angle"
+    description: |
+        Returns the angle in radian between this and given `Number3`.
+    argument-sets:
+        - 
+          - name: "eulerAnglesXYZ"
+            type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+    return: 
+        - type: "number" 
+  
+  - name: "Lerp"
+    description: |
+        Sets this `Number3` to the linear interpolation between two given `Number3` at a given ratio.
+    arguments: 
+      - name: "from"
+        type: "Number3"
+      - name: "to"
+        type: "Number3"
+      - name: "ratio"
+        type: "number"
+  
+  - name: "Set"
+    description: |
+        Sets this `Number3`'s components to the given values.
+    argument-sets:
+        - 
+          - name: "xyz"
+            type: "Number3"
+        - 
+          - name: "x"
+            type: "number"
+          - name: "y"
+            type: "number"
+          - name: "z"
+            type: "number"
 
   - name: "Normalize"
     description: |
-      Normalizes the `Number3`.
-      Scales [X](/reference/number3#property-x), [Y](/reference/number3#property-y) & [Z](/reference/number3#property-z) for the [Length](/reference/number3#property-length) to be `1.0`.
+      Normalizes the `Number3` so that its magnitude(/reference/number3#property-length) becomes `1.0`.
     samples:
       - code: |
           local someNumber3 = Number3(10,0,0)

--- a/lua/docs/content/reference/object.yml
+++ b/lua/docs/content/reference/object.yml
@@ -222,6 +222,18 @@ properties:
 
           Nothing else changes, the [This] remains in the scene and it keeps being affected by the simulation (collisions, etc.).
 
+    - name: "ShadowCookie"
+      type: number
+      description: |
+          Size in world units of the shadow cookie projected under the [This], default is `0.0` (disabled).
+          The shadow cookie, also called blob shadow, is a square texture acting as a cheap alternative to projected shadows.
+
+          If this value is strictly positive, shadow cookies will be displayed when:
+          - the scene has no light source,
+          - the scene has light sources, but they are disabled because the client is using lower quality settings
+
+          Shadow cookies can be used as a fallback to your scene shadows for players with low quality settings, of course, you can also use them instead of shadows as a design choice.
+
     - name: "LocalPosition"
       type: "Number3"
       description: |
@@ -511,8 +523,18 @@ functions:
       description: "Rotates the [This] in its own coordinates system."
       argument-sets:
         - 
-          - name: "angles"
+          - name: "eulerAnglesXYZ"
             type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+        - 
+          - name: "rotation"
+            type: "Rotation"
         - 
           - name: "axis"
             type: "Number3"
@@ -531,8 +553,18 @@ functions:
       description: "Rotate the [This] in the [World] coordinates system."
       argument-sets:
         - 
-          - name: "angles"
+          - name: "eulerAnglesXYZ"
             type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+        - 
+          - name: "rotation"
+            type: "Rotation"
         - 
           - name: "axis"
             type: "Number3"
@@ -549,20 +581,42 @@ functions:
             -- same as o:RotateLocal({0, 0, 1}, math.pi / 2.0)
 
     - name: "RotationLocalToWorld"
-      description: "Converts a local rotation to world coordinate system."
-      arguments: 
-        - name: "p"
-          type: "Number3"
+      description: "Converts a rotation from local to world relative to this object."
+      argument-sets:
+        - 
+          - name: "eulerAnglesXYZ"
+            type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+        - 
+          - name: "rotation"
+            type: "Rotation"
       return:
-        - type: "Number3"
+        - type: "Rotation"
 
     - name: "RotationWorldToLocal"
-      description: "Converts a world rotation to local coordinate system."
-      arguments: 
-        - name: "p"
-          type: "Number3"
+      description: "Converts a rotation from world to local relative to this object."
+      argument-sets:
+        - 
+          - name: "eulerAnglesXYZ"
+            type: "Number3"
+        - 
+          - name: "eulerAngleX"
+            type: "number"
+          - name: "eulerAngleY"
+            type: "number"
+          - name: "eulerAngleZ"
+            type: "number"
+        - 
+          - name: "rotation"
+            type: "Rotation"
       return:
-        - type: "Number3"
+        - type: "Rotation"
 
     - name: "CollidesWith"
       description: "Returns `true` if the two [Object]s may collide with each other."

--- a/lua/docs/content/reference/object.yml
+++ b/lua/docs/content/reference/object.yml
@@ -242,7 +242,7 @@ properties:
           All of [This]'s ancestors local transformations are combined to obtain the [This] "world position" ([Object.Position](#property-position)), the [Object]'s final position.
 
     - name: "Rotation"
-      type: "Number3"
+      type: "Rotation"
       description: |
           Rotation of the [This] in the world (as seen on screen).
 
@@ -271,7 +271,7 @@ properties:
             end
 
     - name: "LocalRotation"
-      type: "Number3"
+      type: "Rotation"
       description: |
           Local rotation of the [This] relative to its parent.
 

--- a/lua/docs/content/reference/player.yml
+++ b/lua/docs/content/reference/player.yml
@@ -73,18 +73,10 @@ properties:
     description: |
         Whether or not the player shapes should be affected by light shadow casters in matching layers.
 
-  - name: "ShadowCookie"
-    type: boolean
-    description: |
-        Whether or not [This] should have a square shadow projected on the map, default is `false`.
-        The size of this shadow is based off [This]'s world bounding box.
-
-        Note that this is a write-only shortcut to the individual player shapes' `shape.ShadowCookie` field.
-
   - name: "Layers"
     type: "table"
     description: |
-        Integer or table of integers between 1 and 8. Cameras only render objects corresponding to their layers.
+        Integer or table of integers between 1 and 12. Cameras only render objects corresponding to their layers.
 
 functions:
   - name: "CastRay"

--- a/lua/docs/content/reference/quad.yml
+++ b/lua/docs/content/reference/quad.yml
@@ -42,6 +42,10 @@ properties:
       type: "number"
       description: |
           Height of the quad model, `1.0` by default.
+    
+    - name: "Size"
+      type: "Number2"
+      description: "Returns the size of the quad model. Equivalent to `Number2(quad.Width, quad.Height)`."
 
     - name: "Anchor"
       type: "Number2"
@@ -79,7 +83,7 @@ properties:
     - name: "Layers"
       type: "table"
       description: |
-          Integer or table of integers between 1 and 8. Cameras only render quads corresponding to their layers, and lights only affect quads in matching layers.
+          Integer or table of integers between 1 and 12. Cameras only render quads corresponding to their layers, and lights only affect quads in matching layers.
 
     - name: "IsUnlit"
       type: "boolean"

--- a/lua/docs/content/reference/rotation.yml
+++ b/lua/docs/content/reference/rotation.yml
@@ -1,0 +1,156 @@
+keywords: ["cubzh", "game", "mobile", "scripting", "cube", "voxel", "world"]
+type: "Rotation"
+description: |
+    A [Rotation] is a transformation that can be applied to an `Object`, a `Number3` or another `Rotation`.
+    
+    It can be created from euler angles, an axis-angle, or from vectors, and can be used as a safe way to store, manipulate, and apply rotations in your scene.
+
+    A table of three numbers can be used in place of an expected [Rotation] argument in all of its functions and most operations.
+
+    Internally, a quaternion is used to represent a [Rotation]. All of its functions as well as the `*` operator use this form. It allows rotations to be applied in a scene of any complexity.
+    However, the `+` and `-` operators are performed on the euler angles form, which may be used on simpler use-cases.
+
+    You can access the euler representation at any time using [Rotation].[X](#property-x), [Rotation].[Y](#property-y) and [Rotation].[Z](#property-z).
+    Note that the euler angles may change despite representing the same rotation, that is because there are several sequences of X, Y, Z rotations leading to the same transformation. This can also be due to euler angles being snapped back into the range 0 to 2PI.
+
+    ⚠️ If you are having issues with rotations in your scene, try to avoid performing calculations using euler angles and instead,
+    - to safely combine rotations, use the `*` operator instead of the `+` / `-` euler operators,
+        - `rotA + rotB` can be replaced by `rotB * rotA`
+        - `rotA - rotB` can be replaced by `-rotB * rotA`
+    - leverage the built-in [Rotation] alternate set functions,
+      [rotation:SetAxisAngle](/reference/rotation#functions-setaxisangle)
+      [rotation:SetLookRotation](/reference/rotation#functions-setlookrotation)
+      [rotation:SetFromToRotation](/reference/rotation#functions-setfromtorotation)
+    - leverage the built-in [Object] rotate functions,
+      [object:RotateLocal](/reference/object#functions-rotatelocal)
+      [object:RotateWorld](/reference/object#functions-rotateworld)
+      [object:RotationLocalToWorld](/reference/object#functions-rotationlocaltoworld)
+      [object:RotationWorldToLocal](/reference/object#functions-rotationworldtolocal)
+    - leverage the built-in [Number3] rotate function,
+      [number3:Rotate](/reference/number3#functions-rotate)
+
+constructors: 
+  - description: |
+        A rotation can be created,
+        - without parameter, rotation will be identity
+        - with euler angles
+        - with axis-angle
+
+        Either way, a quaternion is created and used internally to safely represent that rotation.
+
+    argument-sets:
+      -
+      -
+        - name: "eulerAnglesXYZ"
+          type: "Number3"
+      -
+        - name: "eulerAngleX"
+          type: "number"
+        - name: "eulerAngleY"
+          type: "number"
+        - name: "eulerAngleZ"
+          type: "number"
+      -
+        - name: "axis"
+          type: "Number3"
+        - name: "angle"
+          type: "number"
+
+properties:
+  - name: "X"
+    type: "number"
+    description: "Euler angle around the X axis."
+    
+  - name: "Y"
+    type: "number"
+    description: "Euler angle around the Y axis."
+    
+  - name: "Z"
+    type: "number"
+    description: "Euler angle around the Z axis."
+
+functions:
+  - name: "Copy"
+    return: 
+        - type: "Rotation" 
+    description: |
+        Returns a new [Rotation] as a copy of this rotation.
+          
+  - name: "Inverse"
+    description: |
+        Inverse the rotation. This is safer than negating euler angles.
+        
+        Note that negating a [Rotation] by writing `-myRot` is performing the inverse and returning it.
+
+  - name: "Lerp"
+    description: |
+        Sets this `Rotation` to the linear interpolation between two given rotations at a given ratio.
+
+        This is faster than Slerp, but may not always be appropriate. Use Slerp instead if Lerp doesn't give satisfactory results.
+    arguments:
+      - name: "from"
+        type: "Rotation"
+      - name: "to"
+        type: "Rotation"
+      - name: "ratio"
+        type: "number"
+  
+  - name: "Slerp"
+    description: |
+        Sets this `Rotation` to the spherical interpolation between two given rotations at a given ratio.
+    arguments:
+      - name: "from"
+        type: "Rotation"
+      - name: "to"
+        type: "Rotation"
+      - name: "ratio"
+        type: "number"
+  
+  - name: "Angle"
+    description: |
+        Returns the angle in radians between this rotation and another rotation.
+    arguments:
+      - name: "otherRot"
+        type: "Rotation"
+    return: 
+        - type: "number"
+  
+  - name: "Set"
+    description: |
+        Sets this `Rotation` from euler angles.
+    argument-sets:
+      -
+        - name: "eulerAnglesXYZ"
+          type: "Number3"
+      -
+        - name: "eulerAngleX"
+          type: "number"
+        - name: "eulerAngleY"
+          type: "number"
+        - name: "eulerAngleZ"
+          type: "number"
+
+  - name: "SetAxisAngle"
+    description: |
+        Sets this `Rotation` from axis-angle.
+    arguments:
+      - name: "axis"
+        type: "Number3"
+      - name: "angle"
+        type: "number"
+
+  - name: "SetLookRotation"
+    description: |
+        Sets this `Rotation` from a direction vector. It will be set to the rotation between identity and the given vector.
+    arguments:
+      - name: "vector"
+        type: "Number3"
+
+  - name: "SetFromToRotation"
+    description: |
+        Sets this `Rotation` from two vectors. It will be set to the rotation going from the first vector to the second vector.
+    arguments:
+      - name: "fromVector"
+        type: "Number3"
+      - name: "toVector"
+        type: "Number3"

--- a/lua/docs/content/reference/shape.yml
+++ b/lua/docs/content/reference/shape.yml
@@ -64,7 +64,7 @@ properties:
     - name: "Palette"
       type: "array"
       description: |
-          Palette is an [array] of [Color]s, with each entry corresponding to a [Color] used by the [This].
+          Palette is an [array] of [BlockProperties], with each entry corresponding to a style of block used by the [This]'s model.
 
     - name: "Pivot"
       type: "Number3"
@@ -102,6 +102,11 @@ properties:
       read-only: true
       type: "number"
       description: "Returns [This]'s width, measured in blocks."
+    
+    - name: "Size"
+      read-only: true
+      type: "Number3"
+      description: "Returns [This]'s model bounding box size, measured in blocks. Equivalent to `Number3(shape.Width, shape.Height, shape.Depth)`."
 
     - name: "BoundingBox"
       read-only: true
@@ -140,16 +145,10 @@ properties:
       description: |
           Whether or not the shape should be affected by light shadow casters in matching layers.
 
-    - name: "ShadowCookie"
-      type: boolean
-      description: |
-          Whether or not [This] should have a square shadow projected on the map, default is `false`.
-          The size of the shadow is based off [This]'s collision box.
-
     - name: "Layers"
       type: "table"
       description: |
-          Integer or table of integers between 1 and 8. Cameras only render shapes corresponding to their layers, and lights only affect shapes in matching layers.
+          Integer or table of integers between 1 and 12. Cameras only render shapes corresponding to their layers, and lights only affect shapes in matching layers.
 
     - name: "IsUnlit"
       type: "boolean"

--- a/lua/docs/content/reference/text.yml
+++ b/lua/docs/content/reference/text.yml
@@ -101,7 +101,7 @@ properties:
     - name: "Layers"
       type: "table"
       description: |
-          Integer or table of integers between 1 and 8. Cameras only render objects corresponding to their layers.
+          Integer or table of integers between 1 and 12. Cameras only render objects corresponding to their layers.
 
     - name: "MaxWidth"
       type: "number"


### PR DESCRIPTION
To be merged with 0.0.52 release.

Reference changelog,
- new `Animation` type
- new `Rotation` type
- added `camera:WorldToScreen(number3)` and `camera:ScreenToRay(number2)`
- added `number3:Angle(number3)`
- added `number3:Lerp`, `number2:Lerp`, `color:Lerp`
- added `number3:Set`, `number2:Set`, `color:Set`
- added `quad.Size`, `shape.Size`
- extended signatures for `object:RotateLocal`, `RotateWorld`, `RotationLocalToWorld`, `RotationWorldToLocal` and `number3:Rotate`
- moved `shape/player.ShadowCookie` to `object.ShadowCookie`, and its workings has been updated
- increased number of available `Layers` from `8` to `12`
- increased number of available `CollisionGroups` from `8` to `12`
- fixed a docs error in `shape.Palette`