### PR TITLE
vox file import: fix when RGBA chunk doesn't have 256 entries

### DIFF
--- a/core/magicavoxel.c
+++ b/core/magicavoxel.c
@@ -771,7 +771,7 @@ enum serialization_magicavoxel_error serialization_vox_to_shape(Stream *s,
                 err = invalid_format;
                 break;
             }
-            
+
             int nbColors = minimum(current_chunk_content_bytes / 4, VOX_MAX_NB_COLORS);
 
             for (int i = 0; i < nbColors; i++) {


### PR DESCRIPTION
In the docs, it seems to indicate that RGBA chunk's size is always supposed to be 1024 (256 x 4). 
But it's not always the case when .vox come from softwares other than Magicavoxel. 
Making it more permissive, considering provided chunk size. 