### PR TITLE
item_grid / worlds/ world_details : cleanup + cancel requests, timers ans listeners

### DIFF
--- a/lua/modules/friends.lua
+++ b/lua/modules/friends.lua
@@ -22,6 +22,21 @@ local padding = theme.padding
 local modal = require("modal")
 local api = require("system_api", System)
 
+-- list IDs
+local LIST = {
+	RECEIVED = 1,
+	SENT = 2,
+	FRIENDS = 3,
+	SEARCH = 4,
+}
+
+local TITLES = {
+	"Received (%d)",
+	"Sent (%d)",
+	"Friends (%d)",
+	"Search (%d)",
+}
+
 -- uikit: optional, allows to provide specific instance of uikit
 mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 	local ui = uikit or require("uikit")
@@ -31,7 +46,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 
 	local scroll
 	local searchText
-	local nbResults = -1 -- -1 loading..., 0 no result
+	local loading = true
 
 	-- list of friends, requests (sent or received) or search
 	local lists = {
@@ -84,60 +99,73 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 		cancelRequestsAndTimers()
 
 		searchText = searchStr
-		nbResults = -1
+		loading = true
 		local nbLists = 4
 		local nbListsRetrieved = 0
-		lists = {
-			received = {},
-			sent = {},
-			friends = {},
-			search = {},
-		}
+
+		lists = {}
+		lists[LIST.RECEIVED] = {}
+		lists[LIST.SENT] = {}
+		lists[LIST.FRIENDS] = {}
+		lists[LIST.SEARCH] = {}
+
+		listsN = {}
+		listsN[LIST.RECEIVED] = 0
+		listsN[LIST.SENT] = 0
+		listsN[LIST.FRIENDS] = 0
+		listsN[LIST.SEARCH] = 0
+
 		node:resetList()
 		keepScrollPosition = keepScrollPosition or false
 
-		local function newListResponse(name, list)
-			lists[name] = list or {}
+		local function newListResponse(listID, list)
+			lists[listID] = list or {}
 			nbListsRetrieved = nbListsRetrieved + 1
 			if nbListsRetrieved < nbLists then
 				return
 			end
+
 			if searchText and #searchText > 0 then
 				-- filter out search list
 				-- remove this part once backend handles that
-				for k = #lists.search, 1, -1 do
-					local user = lists.search[k]
+				for k = #lists[LIST.SEARCH], 1, -1 do
+					local user = lists[LIST.SEARCH][k]
 					local idFound = false
-					for _, v in ipairs(lists.friends) do
+					for _, v in ipairs(lists[LIST.FRIENDS]) do
 						if v.id == user.id then
 							idFound = true
 						end
 					end
-					for _, v in ipairs(lists.received) do
+					for _, v in ipairs(lists[LIST.RECEIVED]) do
 						if v.id == user.id then
 							idFound = true
 						end
 					end
-					for _, v in ipairs(lists.sent) do
+					for _, v in ipairs(lists[LIST.SENT]) do
 						if v.id == user.id then
 							idFound = true
 						end
 					end
 					if idFound then
-						table.remove(lists.search, k)
+						table.remove(lists[LIST.SEARCH], k)
 					end
 				end
-				nbResults = #lists.friends + #lists.received + #lists.sent + #lists.search
-			else
-				nbResults = #lists.friends + #lists.received
 			end
+
+			listsN[LIST.RECEIVED] = #lists[LIST.RECEIVED]
+			listsN[LIST.SENT] = #lists[LIST.SENT]
+			listsN[LIST.FRIENDS] = #lists[LIST.FRIENDS]
+			listsN[LIST.SEARCH] = #lists[LIST.SEARCH]
+
+			loading = false
+
 			node:resetList(keepScrollPosition)
 		end
 
-		local function requestList(methodName, listName, searchText)
+		local function requestList(methodName, listID, searchText)
 			local list = {}
 			local nbIterations = 0
-			if listName == "search" then
+			if listID == LIST.SEARCH then
 				if searchText == nil or searchText == "" then
 					newListResponse("search", {})
 					return
@@ -158,7 +186,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 							table.sort(list, function(a, b)
 								return a.username < b.username
 							end)
-							newListResponse(listName, list)
+							newListResponse(listID, list)
 						end
 					end
 				end)
@@ -172,12 +200,16 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 					error("Can't find users", 2)
 				end
 				if #users == 0 then
-					newListResponse(listName, {})
+					newListResponse(listID, {})
 					return
 				end
 				for _, usrID in ipairs(users) do
-					local req2 = api:getUserInfo(usrID, function(_, usr)
-						-- TODO: handle errors
+					local req2 = api:getUserInfo(usrID, function(success, usr)
+						if success == false then
+							-- TODO: handle errors
+							-- insert ERROR CELL
+							return
+						end
 						if usr.username ~= "" then
 							-- if search, match the username
 							if not searchText or string.find(usr.username, searchText) then
@@ -186,10 +218,10 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 						end
 						nbIterations = nbIterations + 1
 						if nbIterations == #users then
-							table.sort(list, function(a, b)
-								return a.username < b.username
-							end)
-							newListResponse(listName, list)
+							-- table.sort(list, function(a, b)
+							-- 	return a.username < b.username -- ERROR: compare 2 nil values
+							-- end)
+							newListResponse(listID, list)
 						end
 					end)
 					table.insert(requests, req2)
@@ -198,10 +230,10 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 			table.insert(requests, req)
 		end
 
-		requestList("getFriends", "friends", searchText)
-		requestList("getReceivedFriendRequests", "received", searchText)
-		requestList("getSentFriendRequests", "sent", searchText)
-		requestList("searchUser", "search", searchText)
+		requestList("getFriends", LIST.FRIENDS, searchText)
+		requestList("getReceivedFriendRequests", LIST.RECEIVED, searchText)
+		requestList("getSentFriendRequests", LIST.SENT, searchText)
+		requestList("searchUser", LIST.SEARCH, searchText)
 	end
 
 	local getSearchBar = function()
@@ -381,7 +413,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 		end
 
 		cell.setType = function(_, cellType)
-			if cellType == "received" then
+			if cellType == LIST.RECEIVED then
 				btnLeft.Text = "✅ Accept"
 				btnLeft:show()
 				btnLeft.onRelease = function()
@@ -404,7 +436,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 					end)
 					table.insert(requests, req)
 				end
-			elseif cellType == "sent" then
+			elseif cellType == LIST.SENT then
 				btnLeft.Text = "Sent"
 				btnLeft:show()
 				btnLeft.onRelease = nil
@@ -419,7 +451,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 					end)
 					table.insert(requests, req)
 				end
-			elseif cellType == "friends" then
+			elseif cellType == LIST.FRIENDS then
 				btnLeft.Text = "🌎 Join"
 				btnLeft:show()
 				btnLeft.onRelease = function()
@@ -430,7 +462,7 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 				btnRight.onRelease = function()
 					require("menu"):ShowAlert({ message = "Coming soon!" }, System)
 				end
-			elseif cellType == "search" then
+			elseif cellType == LIST.SEARCH then
 				btnLeft.Text = "➕ Add friend"
 				btnLeft:show()
 				btnLeft.onRelease = function()
@@ -452,30 +484,8 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 		return cell
 	end
 
-	local getUserAtIndex = function(index, nbCellsPerLine)
-		-- default list
-		local listOrder = { "received", "friends" }
-		if #lists.search > 0 then
-			-- search list
-			listOrder = { "friends", "received", "sent", "search" }
-		end
-
-		for _, name in ipairs(listOrder) do
-			local list = lists[name]
-			if list then
-				-- compute nb lines (add empty spaces)
-				local nbLines = math.ceil(#list / nbCellsPerLine)
-				local totalCells = nbLines * nbCellsPerLine
-				if index <= totalCells then
-					return list[index], name
-				end
-				index = index - totalCells
-			end
-		end
-	end
-
 	local loadLine = function(cellId)
-		if nbResults == -1 then
+		if loading == true then
 			if cellId == 1 then
 				local container = ui:createFrame()
 				local text = ui:createText("Loading...", Color.White)
@@ -487,6 +497,12 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 			end
 			return
 		end
+
+		local nbResults = 0
+		for _, n in ipairs(listsN) do
+			nbResults = nbResults + n
+		end
+
 		if nbResults == 0 then
 			if cellId == 1 then
 				local container = ui:createFrame()
@@ -507,83 +523,78 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 		end
 
 		local width = node.Width
-		local nbCells = math.min(Client.IsMobile and 4 or 2, math.floor(width / cellWidth))
+		-- nb cells per line
+		local nbCellsPerLine = math.floor(width / cellWidth)
 
-		local firstUserCell, firstCellType = getUserAtIndex((cellId - 1) * nbCells + 1, nbCells)
-		if not firstUserCell then
-			return
-		end
+		local getContentForLine = function(lineNumber, nbCellsPerLine)
+			nbCellsPerLine = math.floor(nbCellsPerLine)
+			local l = 1
+			while l <= #lists do
+				if listsN[l] == 0 then
+					l = l + 1 -- nothing in that list, look in next one
+				elseif lineNumber == 1 then
+					return lists[l], l, true -- first line : title
+				else
+					local nbLinesForList = math.floor(listsN[l] / nbCellsPerLine)
+						+ (listsN[l] % nbCellsPerLine > 0 and 1 or 0)
 
-		local prevFirstCellUserType
-		if cellId > 1 then
-			_, prevFirstCellUserType = getUserAtIndex((cellId - 2) * nbCells + 1, nbCells)
-		end
-
-		local verticalContainer
-		local line = require("ui_container"):createHorizontalContainer()
-		line.Width = math.floor(width)
-		line.Height = math.floor(cellHeight)
-		line.cells = {}
-		line.onRemove = function()
-			for _, cell in ipairs(line.cells) do
-				if cell.avatar then
-					cell.avatar:setParent(nil)
-					cell.avatar = nil
-				end
-				for _, r in ipairs(cell.requests) do
-					r:Cancel()
-				end
-				cell.requests = {}
-				if cell.waitScrollStopTimer then
-					cell.waitScrollStopTimer:Cancel()
-					cell.waitScrollStopTimer = nil
+					if lineNumber - 1 <= nbLinesForList then
+						local start = (lineNumber - 2) * nbCellsPerLine + 1
+						local stop = math.min(start + nbCellsPerLine - 1, listsN[l])
+						return lists[l], l, nil, { start, stop }
+					else
+						l = l + 1
+						lineNumber = lineNumber - 1 - nbLinesForList
+					end
 				end
 			end
 		end
-		-- Need to make a vertical container to add the title
-		if prevFirstCellUserType == nil or firstCellType ~= prevFirstCellUserType then
-			local titles = {
-				friends = "Friends (%d)",
-				received = "Pending Requests (%d)",
-				sent = "Sent Requests (%d)",
-				search = "Search (%d)",
-			}
-			local titleStr = titles[firstCellType]
-			if titleStr then
-				verticalContainer = require("ui_container"):createVerticalContainer()
-				local title = ui:createText(string.format(titleStr, #lists[firstCellType]), Color.White)
-				verticalContainer:pushElement(title)
-				verticalContainer:pushElement(line)
-				verticalContainer.line = line
-			else
-				line:pushGap()
-			end
-		else
-			line:pushGap()
+
+		local list, listID, title, range = getContentForLine(cellId, nbCellsPerLine)
+
+		-- print("listID:", listID, "title:", title, "range:", range[1], range[2])
+
+		if title then
+			local titleStr = TITLES[listID]
+			return ui:createText(string.format(titleStr, listsN[listID]), Color.White)
 		end
 
-		-- Stretch width to fit the full length
-		local realCellWidth = math.floor((width - 2 * padding - (nbCells - 1) * 3 * padding) / nbCells)
-		for i = 1, nbCells do
-			local cell = createFriendCell({ width = realCellWidth, height = cellHeight })
-			line:pushElement(cell)
-			if i < nbCells then
-				line:pushGap()
-				line:pushGap()
-				line:pushGap()
+		if list and range then
+			local line = require("ui_container"):createHorizontalContainer()
+			line.cells = {}
+			line.onRemove = function()
+				for _, cell in ipairs(line.cells) do
+					if cell.avatar then
+						cell.avatar:setParent(nil)
+						cell.avatar = nil
+					end
+					for _, r in ipairs(cell.requests) do
+						r:Cancel()
+					end
+					cell.requests = {}
+					if cell.waitScrollStopTimer then
+						cell.waitScrollStopTimer:Cancel()
+						cell.waitScrollStopTimer = nil
+					end
+				end
 			end
-			table.insert(line.cells, cell)
 
-			local user, cellType = getUserAtIndex((cellId - 1) * nbCells + i, nbCells)
-			if user then
-				cell:setUser(user)
-				cell:setType(cellType)
-			elseif getUserAtIndex(1, nbCells) ~= nil then
-				cell:hide()
+			local start = range[1]
+			for i = start, range[2] do
+				local cell = createFriendCell({ width = cellWidth, height = cellHeight })
+				if i > start then
+					line:pushGap()
+				end
+				line:pushElement(cell)
+
+				table.insert(line.cells, cell)
+
+				cell:setUser(list[i])
+				cell:setType(listID)
 			end
+
+			return line
 		end
-
-		return verticalContainer or line
 	end
 
 	local unloadLine = function(lineOrVerticalContainer)

--- a/lua/modules/item_details.lua
+++ b/lua/modules/item_details.lua
@@ -1,27 +1,19 @@
 itemDetails = {}
 
 itemDetails.createModalContent = function(_, config)
-	local _config = {
+	local api = require("system_api", System)
+	local time = require("time")
+	local theme = require("uitheme").current
+
+	local defaultConfig = {
 		title = "Item",
 		mode = "explore", -- "explore" / "create"
 		uikit = require("uikit"),
 	}
 
-	if config then
-		for k, v in pairs(_config) do
-			if type(config[k]) == type(v) then
-				_config[k] = config[k]
-			end
-		end
-	end
-
-	config = _config
+	config = require("config"):merge(defaultConfig, config)
 
 	local ui = config.uikit
-
-	local api = require("system_api", System)
-	local time = require("time")
-	local theme = require("uitheme").current
 
 	local itemDetails = ui:createNode()
 
@@ -30,12 +22,11 @@ itemDetails.createModalContent = function(_, config)
 
 	-- becomes true when itemDetails is removed
 	-- callbacks may capture this as upvalue to early return.
-	local removed = false
 	local requests = {}
+	local refreshTimer
 	local listeners = {}
 
-	itemDetails.onRemove = function(_)
-		removed = true
+	local cancelRequestsTimersAndListeners = function()
 		for _, req in ipairs(requests) do
 			req:Cancel()
 		end
@@ -45,6 +36,15 @@ itemDetails.createModalContent = function(_, config)
 			listener:Remove()
 		end
 		listeners = {}
+
+		if refreshTimer ~= nil then
+			refreshTimer:Cancel()
+			refreshTimer = nil
+		end
+	end
+
+	itemDetails.onRemove = function(_)
+		cancelRequestsTimersAndListeners()
 	end
 
 	local content = require("modal"):createContent()
@@ -169,9 +169,6 @@ itemDetails.createModalContent = function(_, config)
 							description.Color = theme.textColorSecondary
 							description.pos.Y = descriptionArea.Height - description.Height - theme.padding
 							local req = api:patchItem(itemDetails.id, { description = "" }, function(_, _)
-								if removed then
-									return
-								end
 								-- not handling response yet
 							end)
 							table.insert(requests, req)
@@ -181,9 +178,6 @@ itemDetails.createModalContent = function(_, config)
 							description.Color = theme.textColor
 							description.pos.Y = descriptionArea.Height - description.Height - theme.padding
 							local req = api:patchItem(itemDetails.id, { description = text }, function(_, _)
-								if removed then
-									return
-								end
 								-- not handling response yet
 							end)
 							table.insert(requests, req)
@@ -205,10 +199,6 @@ itemDetails.createModalContent = function(_, config)
 			return
 		end
 		local req = Object:Load(self.cell.itemFullName, function(obj)
-			if removed then
-				return
-			end
-
 			if obj == nil then
 				return
 			end
@@ -243,9 +233,6 @@ itemDetails.createModalContent = function(_, config)
 	end
 
 	content.loadCell = function(_, cell)
-		if removed then
-			return
-		end
 		local self = itemDetails
 
 		if self.shape then
@@ -260,10 +247,7 @@ itemDetails.createModalContent = function(_, config)
 		else
 			-- Retrieve user data. We need their UserID.
 			local req = api:searchUser(cell.repo, function(_, users)
-				if removed then
-					return
-				end
-
+				-- TODO: handle error
 				by.Text = "by @" .. cell.repo
 
 				for _, u in pairs(users) do
@@ -288,10 +272,7 @@ itemDetails.createModalContent = function(_, config)
 		-- Retrieve item info. We need its number of likes.
 		-- (cell.id is Item UUID)
 		local req = api:getItem(cell.id, function(_, item)
-			if removed then
-				return
-			end
-
+			-- TODO: handle error
 			local likes = item.likes or 0
 
 			if self.likes then
@@ -331,11 +312,7 @@ itemDetails.createModalContent = function(_, config)
 			self.likeBtn.Text = "❤️ " .. (cell.likes and math.floor(cell.likes) or "…")
 			self.likeBtn.onRelease = function()
 				self.liked = not self.liked
-				local req = api:likeItem(cell.id, self.liked, function(_)
-					if removed then
-						return
-					end
-				end)
+				local req = api:likeItem(cell.id, self.liked, function(_) end)
 				table.insert(requests, req)
 
 				if self.liked then
@@ -409,16 +386,15 @@ itemDetails.createModalContent = function(_, config)
 	itemDetails._w = 400
 	itemDetails._h = 400
 
-	itemDetails._refreshTimer = nil
 	itemDetails._scheduleRefresh = function(self)
-		if self._refreshTimer ~= nil then
+		if refreshTimer ~= nil then
 			return
 		end
-		self._refreshTimer = Timer(0.01, function()
+		refreshTimer = Timer(0.01, function()
 			if self == nil or self.refresh == nil then
 				return
 			end
-			self._refreshTimer = nil
+			refreshTimer = nil
 			self:refresh()
 		end)
 	end

--- a/lua/modules/item_details.lua
+++ b/lua/modules/item_details.lua
@@ -246,8 +246,13 @@ itemDetails.createModalContent = function(_, config)
 			self.author.Text = " @" .. cell.repo
 		else
 			-- Retrieve user data. We need their UserID.
-			local req = api:searchUser(cell.repo, function(_, users)
-				-- TODO: handle error
+			local req = api:searchUser(cell.repo, function(success, users)
+				if success == false then
+					-- don't do anything on failure
+					-- api module should implement retry strategy
+					return
+				end
+
 				by.Text = "by @" .. cell.repo
 
 				for _, u in pairs(users) do
@@ -271,8 +276,13 @@ itemDetails.createModalContent = function(_, config)
 		end
 		-- Retrieve item info. We need its number of likes.
 		-- (cell.id is Item UUID)
-		local req = api:getItem(cell.id, function(_, item)
-			-- TODO: handle error
+		local req = api:getItem(cell.id, function(err, item)
+			if err ~= nil then
+				-- don't do anything on failure
+				-- api module should implement retry strategy
+				return
+			end
+
 			local likes = item.likes or 0
 
 			if self.likes then

--- a/lua/modules/item_details.lua
+++ b/lua/modules/item_details.lua
@@ -167,21 +167,16 @@ itemDetails.createModalContent = function(_, config)
 							description.empty = true
 							description.Text = "Items are easier to find with a description!"
 							description.Color = theme.textColorSecondary
-							description.pos.Y = descriptionArea.Height - description.Height - theme.padding
-							local req = api:patchItem(itemDetails.id, { description = "" }, function(_, _)
-								-- not handling response yet
-							end)
-							table.insert(requests, req)
 						else
 							description.empty = false
 							description.Text = text
 							description.Color = theme.textColor
-							description.pos.Y = descriptionArea.Height - description.Height - theme.padding
-							local req = api:patchItem(itemDetails.id, { description = text }, function(_, _)
-								-- not handling response yet
-							end)
-							table.insert(requests, req)
 						end
+						description.pos.Y = descriptionArea.Height - description.Height - theme.padding
+						local req = api:patchItem(itemDetails.id, { description = text }, function(_, _)
+							-- not handling response yet
+						end)
+						table.insert(requests, req)
 					end,
 					function() -- cancel
 						ui:turnOn()

--- a/lua/modules/item_grid.lua
+++ b/lua/modules/item_grid.lua
@@ -79,8 +79,6 @@ itemGrid.create = function(_, config)
 
 	local ui = config.uikit
 
-	local removed = false
-
 	local sortBy = "likes:desc"
 
 	local grid = ui:createFrame() -- Color(255,0,0)
@@ -135,9 +133,6 @@ itemGrid.create = function(_, config)
 	end
 
 	grid.setCategories = function(self, categories, type)
-		if self.getItems == nil then
-			return
-		end
 		if type ~= nil then
 			config.type = type
 		end
@@ -147,9 +142,6 @@ itemGrid.create = function(_, config)
 	end
 
 	grid.setWorldsFilter = function(self, filter)
-		if self.getItems == nil then
-			return
-		end
 		if filter == nil or type(filter) ~= Type.string then
 			error("item_grid:setWorldsFilter(filter): filter should be a string", 2)
 		end
@@ -252,7 +244,6 @@ itemGrid.create = function(_, config)
 		cancelRequestsAndTimers()
 		grid.tickListener:Remove()
 		grid.tickListener = nil
-		removed = true
 	end
 
 	grid._createCell = function(grid, size)
@@ -447,10 +438,6 @@ itemGrid.create = function(_, config)
 			end
 
 			local req = Object:Load(itemName, function(obj)
-				if removed then
-					return
-				end
-
 				if not cell.tName then
 					return
 				end
@@ -466,6 +453,7 @@ itemGrid.create = function(_, config)
 					end
 					return
 				end
+
 				if cell.item then
 					cell.item:remove()
 					cell.item = nil
@@ -604,9 +592,6 @@ itemGrid.create = function(_, config)
 	end
 
 	grid.refresh = function(self)
-		if removed then
-			return
-		end
 		cancelCellContentRequest()
 
 		if self ~= grid then
@@ -780,14 +765,11 @@ itemGrid.create = function(_, config)
 		self:_paginationDidChange()
 	end
 
-	grid.dt = 0.0
-	grid.dt4 = 0.0
+	local dt1 = 0.0
+	local dt4 = 0.0
 	grid.tickListener = LocalEvent:Listen(LocalEvent.Name.Tick, function(dt)
-		if grid.dt == nil then
-			return
-		end
-		grid.dt = grid.dt + dt
-		grid.dt4 = grid.dt4 + dt * 4
+		dt1 = dt1 + dt
+		dt4 = dt4 + dt * 4
 
 		local cells = grid.cells
 		if cells == nil then
@@ -795,7 +777,7 @@ itemGrid.create = function(_, config)
 		end
 		local loadingCube
 		local center = grid.cellSize * 0.5
-		local loadingCubePos = { center + math.cos(grid.dt4) * 20, center - math.sin(grid.dt4) * 20, 0 }
+		local loadingCubePos = { center + math.cos(dt4) * 20, center - math.sin(dt4) * 20, 0 }
 		for _, c in ipairs(cells) do
 			if c.getLoadingCube == nil then
 				return
@@ -806,7 +788,7 @@ itemGrid.create = function(_, config)
 			end
 
 			if c.item ~= nil and c.item.pivot ~= nil then
-				c.item.pivot.LocalRotation = { -0.1, grid.dt, -0.2 }
+				c.item.pivot.LocalRotation = { -0.1, dt1, -0.2 }
 			end
 		end
 	end)

--- a/lua/modules/modal.lua
+++ b/lua/modules/modal.lua
@@ -243,6 +243,7 @@ end
 -- uikit: optional, allows to provide specific instance of uikit
 modal.create = function(_, content, maxWidth, maxHeight, position, uikit)
 	local theme = require("uitheme").current
+	local ease = require("ease")
 
 	local ui = uikit or require("uikit")
 
@@ -949,6 +950,8 @@ modal.create = function(_, content, maxWidth, maxHeight, position, uikit)
 		if active ~= nil and active.willResignActive ~= nil then
 			active:willResignActive()
 		end
+
+		ease:cancel(self) -- cancel eventual easing
 
 		-- if self._content.onClose ~= nil then
 		-- 	self._content:onClose()

--- a/lua/modules/profile.lua
+++ b/lua/modules/profile.lua
@@ -11,7 +11,6 @@ ui = require("uikit")
 uiAvatar = require("ui_avatar")
 pages = require("pages")
 colorpicker = require("colorpicker")
-ease = require("ease")
 
 -- CONSTANTS
 
@@ -30,88 +29,6 @@ local DEBUG = false
 local DEBUG_FRAME_COLOR = Color(255, 255, 0, 200)
 
 local ACTIVE_NODE_MARGIN = theme.paddingBig
-
-local lastMinimizedProfileModal
-
-function updateFriendBtn(friendBtn, content, userID)
-	if Player.UserID == userID then
-		friendBtn.Text = string.format("📘 Friends")
-		friendBtn.onRelease = function()
-			Menu:ShowFriends()
-		end
-	else
-		friendBtn.onRelease = function()
-			api:sendFriendRequest(userID, function(ok, _)
-				if not ok then
-					return
-				end
-				friendBtn.Text = "📩 Invitation sent"
-				content:refreshModal()
-			end)
-		end
-	end
-
-	-- check if the User is already a friend
-	api:getFriends(function(ok, friends, _)
-		if not ok then
-			return
-		end
-		if Player.UserID == userID then
-			friendBtn.Text = string.format("📘 Friends (%d)", #friends)
-			friendBtn.onRelease = function()
-				Menu:ShowFriends()
-			end
-			content:refreshModal()
-			return
-		end
-		for _, friendID in ipairs(friends) do
-			if friendID == userID then
-				friendBtn.Text = "💬 Message"
-				friendBtn.onRelease = function()
-					local alert = require("alert"):create("⚠️ Work in progress...", { uikit = ui })
-					alert.pos.Z = -500
-				end
-				content:refreshModal()
-				break
-			end
-		end
-	end)
-
-	api:getSentFriendRequests(function(ok, users, _)
-		if not ok then
-			return
-		end
-		for _, friendID in ipairs(users) do
-			if friendID == userID then
-				friendBtn.Text = "📩 Invitation sent"
-				friendBtn.onRelease = nil
-				content:refreshModal()
-				break
-			end
-		end
-	end)
-
-	api:getReceivedFriendRequests(function(ok, users, _)
-		if not ok then
-			return
-		end
-		for _, friendID in ipairs(users) do
-			if friendID == userID then
-				friendBtn.Text = "➕ Add Friend"
-				friendBtn.onRelease = function()
-					api:replyToFriendRequest(userID, true, function()
-						friendBtn.Text = "💬 Message"
-						friendBtn.onRelease = function()
-							require("alert"):create("⚠️ Work in progress...", { uikit = ui })
-						end
-						content:refreshModal()
-					end)
-				end
-				break
-			end
-		end
-	end)
-end
 
 --- Creates a profile modal content
 --- positionCallback(function): position of the popup

--- a/lua/modules/ui_container.lua
+++ b/lua/modules/ui_container.lua
@@ -60,6 +60,11 @@ local horizontalContainerRefresh = function(self)
 end
 
 local createHorizontalContainer = function(_, config)
+	-- legacy
+	if type(config) == "Color" then
+		config = { color = config }
+	end
+
 	config = require("config"):merge(defaultConfig, config)
 
 	local container = uikit:createFrame(config.color)
@@ -117,6 +122,11 @@ local verticalContainerRefresh = function(self)
 end
 
 local createVerticalContainer = function(_, config)
+	-- legacy
+	if type(config) == "Color" then
+		config = { color = config }
+	end
+
 	config = require("config"):merge(defaultConfig, config)
 
 	local container = uikit:createFrame(config.color)

--- a/lua/modules/ui_container.lua
+++ b/lua/modules/ui_container.lua
@@ -24,6 +24,11 @@ local pushSeparator = function(self)
 	self:refresh()
 end
 
+local defaultConfig = {
+	gapSize = PADDING,
+	color = Color(0, 0, 0, 0), -- background color
+}
+
 local horizontalContainerRefresh = function(self)
 	local width = 0
 	local height = 0
@@ -46,7 +51,7 @@ local horizontalContainerRefresh = function(self)
 			elem.pos.Y = SEPARATOR_INSET
 			width = width + elem.Width + PADDING * 2
 		elseif elem.elementType == "gap" then
-			width = width + PADDING
+			width = width + self.config.gapSize
 		end
 	end
 
@@ -54,9 +59,12 @@ local horizontalContainerRefresh = function(self)
 	self.Height = height
 end
 
-local createHorizontalContainer = function(_, color)
-	local container = uikit:createFrame(color or Color(0, 0, 0, 0))
+local createHorizontalContainer = function(_, config)
+	config = require("config"):merge(defaultConfig, config)
+
+	local container = uikit:createFrame(config.color)
 	container.list = {}
+	container.config = config
 
 	container.pushElement = pushElement
 	container.pushSeparator = pushSeparator
@@ -81,7 +89,7 @@ local verticalContainerRefresh = function(self)
 		elseif elem.elementType == "separator" then
 			width = height + 1 + PADDING * 2
 		elseif elem.elementType == "gap" then
-			height = height + PADDING
+			height = height + self.config.gapSize
 		end
 	end
 
@@ -108,9 +116,12 @@ local verticalContainerRefresh = function(self)
 	self.Height = height
 end
 
-local createVerticalContainer = function(_, color)
-	local container = uikit:createFrame(color or Color(0, 0, 0, 0))
+local createVerticalContainer = function(_, config)
+	config = require("config"):merge(defaultConfig, config)
+
+	local container = uikit:createFrame(config.color)
 	container.list = {}
+	container.config = config
 
 	container.pushElement = pushElement
 	container.pushSeparator = pushSeparator

--- a/lua/modules/ui_container.lua
+++ b/lua/modules/ui_container.lua
@@ -1,180 +1,127 @@
-local padding = require("uitheme").current.padding
+local SEPARATOR_INSET = require("uitheme").current.paddingTiny
+local PADDING = require("uitheme").current.padding
+local uikit = require("uikit")
 
-local uiHorizontalIndex = {}
-
-uiHorizontalIndex.pushElement = function(self, node)
-	node:setParent(self.bg)
+local pushElement = function(self, node)
+	node:setParent(self)
 	node.elementType = "node"
 	table.insert(self.list, node)
 	self:refresh()
 end
 
-uiHorizontalIndex.pushSeparator = function(self)
-	self:pushGap()
+local pushGap = function(self)
+	local gap = {}
+	gap.elementType = "gap"
+	table.insert(self.list, gap)
+	self:refresh()
+end
+
+local pushSeparator = function(self)
 	local separator = require("uikit"):createFrame(Color.Grey)
 	separator.elementType = "separator"
 	separator.Width = 1
-	separator.Height = self.Height
-	separator:setParent(self.bg)
 	table.insert(self.list, separator)
-	self:pushGap()
 	self:refresh()
 end
 
-uiHorizontalIndex.pushGap = function(self)
-	local gap = require("uikit"):createFrame()
-	gap.elementType = "gap"
-	gap.Width = require("uitheme").current.padding
-	gap.Height = self.Height
-	gap:setParent(self.bg)
-	table.insert(self.list, gap)
-	self:refresh()
-end
+local horizontalContainerRefresh = function(self)
+	local width = 0
+	local height = 0
 
-uiHorizontalIndex.setParent = function(self, node)
-	self.bg:setParent(node)
-end
-
-uiHorizontalIndex.refresh = function(self)
-	local width, height = 0, 0
 	for _, elem in ipairs(self.list) do
-		elem.pos.X = width
-		elem.pos.Y = padding
-		width = math.floor(width + elem.Width)
-		if elem.elementType == "node" and height < elem.Height then
-			height = elem.Height
+		if elem.elementType == "node" then
+			height = math.max(elem.Height, height)
 		end
 	end
 
 	for _, elem in ipairs(self.list) do
-		elem.Height = math.floor(height)
+		if elem.elementType == "node" then
+			elem.pos.X = width
+			elem.pos.Y = height * 0.5 - elem.Height * 0.5
+			width = width + elem.Width
+		elseif elem.elementType == "separator" then
+			elem.pos.X = width + PADDING
+			elem.Width = 1
+			elem.Height = height - SEPARATOR_INSET * 2
+			elem.pos.Y = SEPARATOR_INSET
+			width = width + elem.Width + PADDING * 2
+		elseif elem.elementType == "gap" then
+			width = width + PADDING
+		end
 	end
-	width, height = width, height + padding * 2
-	self.Width = math.floor(width)
-	self.Height = math.floor(height)
+
+	self.Width = width
+	self.Height = height
 end
 
 local createHorizontalContainer = function(_, color)
-	local elem = {}
-	elem.bg = require("uikit"):createFrame(color)
-	local list = {}
+	local container = uikit:createFrame(color or Color(0, 0, 0, 0))
+	container.list = {}
 
-	local index = function(_, k)
-		if k == "list" then
-			return list
-		end
-		return uiHorizontalIndex[k] or elem.bg[k]
-	end
-	local newindex = function(_, k, v)
-		if k == "list" then
-			list = v
-			return
-		end
-		elem.bg[k] = v
+	container.pushElement = pushElement
+	container.pushSeparator = pushSeparator
+	container.pushGap = pushGap
+	container.refresh = horizontalContainerRefresh
+
+	container.parentDidResizeSystem = function(self)
+		horizontalContainerRefresh(self)
 	end
 
-	elem.bg.parentDidResize = function()
-		elem:refresh()
-	end
-	elem.bg.contentDidResize = function()
-		elem:refresh()
-	end
-
-	local metatable = { __metatable = false, __index = index, __newindex = newindex }
-	setmetatable(elem, metatable)
-
-	return elem
+	return container
 end
 
-local uiVerticalIndex = {}
-
-uiVerticalIndex.pushElement = function(self, node)
-	node:setParent(self.bg)
-	node.elementType = "node"
-	table.insert(self.list, node)
-	self:refresh()
-end
-
-uiVerticalIndex.pushSeparator = function(self)
-	self:pushGap()
-	local separator = require("uikit"):createFrame(Color.Grey)
-	separator.elementType = "separator"
-	separator.Width = self.Width
-	separator.Height = 1
-	separator:setParent(self.bg)
-	table.insert(self.list, separator)
-	self:pushGap()
-	self:refresh()
-end
-
-uiVerticalIndex.pushGap = function(self)
-	local gap = require("uikit"):createFrame()
-	gap.elementType = "gap"
-	gap.Width = self.Width
-	gap.Height = require("uitheme").current.padding
-	gap:setParent(self.bg)
-	table.insert(self.list, gap)
-	self:refresh()
-end
-
-uiVerticalIndex.setParent = function(self, node)
-	self.bg:setParent(node)
-end
-
-uiVerticalIndex.refresh = function(self)
-	local width, height = 0, 0
+local verticalContainerRefresh = function(self)
+	local width = 0
+	local height = 0
 
 	for _, elem in ipairs(self.list) do
-		height = height + elem.Height
-	end
-	self.Height = math.floor(height + 2 * padding)
-
-	height = self.Height - padding
-	for _, elem in ipairs(self.list) do
-		elem.pos.X = padding
-		elem.pos.Y = height - elem.Height
-		height = height - elem.Height
-		if width < elem.Width then
-			width = elem.Width
+		if elem.elementType == "node" then
+			width = math.max(elem.Width, width)
+			height = height + elem.Height
+		elseif elem.elementType == "separator" then
+			width = height + 1 + PADDING * 2
+		elseif elem.elementType == "gap" then
+			height = height + PADDING
 		end
 	end
 
+	local cursorY = height
+
 	for _, elem in ipairs(self.list) do
-		elem.Width = width
+		if elem.elementType == "node" then
+			cursorY = cursorY - elem.Height
+			elem.pos.X = width * 0.5 - elem.Width * 0.5
+			elem.pos.Y = cursorY
+		elseif elem.elementType == "separator" then
+			cursorY = cursorY - 1 - PADDING
+			elem.pos.Y = cursorY
+			cursorY = cursorY - PADDING
+			elem.pos.X = SEPARATOR_INSET
+			elem.Width = width - SEPARATOR_INSET * 2
+			elem.Height = 1
+		elseif elem.elementType == "gap" then
+			cursorY = cursorY - PADDING
+		end
 	end
-	self.Width = math.floor(width + 2 * padding)
+
+	self.Width = width
+	self.Height = height
 end
 
 local createVerticalContainer = function(_, color)
-	local elem = {}
-	elem.bg = require("uikit"):createFrame(color)
-	local list = {}
+	local container = uikit:createFrame(color or Color(0, 0, 0, 0))
+	container.list = {}
 
-	local index = function(_, k)
-		if k == "list" then
-			return list
-		end
-		return uiVerticalIndex[k] or elem.bg[k]
-	end
-	local newindex = function(_, k, v)
-		if k == "list" then
-			list = v
-			return
-		end
-		elem.bg[k] = v
+	container.pushElement = pushElement
+	container.pushSeparator = pushSeparator
+	container.pushGap = pushGap
+	container.refresh = verticalContainerRefresh
+
+	container.parentDidResizeSystem = function(self)
+		verticalContainerRefresh(self)
 	end
 
-	elem.bg.parentDidResize = function()
-		elem:refresh()
-	end
-	elem.bg.contentDidResize = function()
-		elem:refresh()
-	end
-
-	local metatable = { __metatable = false, __index = index, __newindex = newindex }
-	setmetatable(elem, metatable)
-
-	return elem
+	return container
 end
 
 return {

--- a/lua/modules/uikit.lua
+++ b/lua/modules/uikit.lua
@@ -2043,9 +2043,8 @@ function createUI(system)
 		return node
 	end
 
-	ui.createScrollArea = function(_, color, config)
-		local ui = config.uikit or require("uikit")
-		local node = ui:createFrame(color)
+	ui.createScrollArea = function(self, color, config)
+		local node = self:createFrame(color)
 		node.isScrollArea = true
 
 		local cellPadding = config.cellPadding or 0
@@ -2058,7 +2057,7 @@ function createUI(system)
 		local dragging = false
 		local dragPointerIndex = nil -- pointerIndex used to drag
 
-		local container = ui:createFrame()
+		local container = self:createFrame()
 		container:setParent(node)
 		container.IsMask = true
 		node.container = container
@@ -2071,7 +2070,7 @@ function createUI(system)
 		local maxY = 0
 		node.scrollPosition = 0
 
-		local scrollHandle = ui:createFrame(Color(0, 0, 0, 0)) -- TODO: work on handle
+		local scrollHandle = self:createFrame(Color(0, 0, 0, 0)) -- TODO: work on handle
 		scrollHandle:setParent(node)
 
 		node.refresh = function()
@@ -2238,7 +2237,7 @@ function createUI(system)
 			node:setScrollPosition(0)
 		end
 
-		local scrollFrame = ui:createFrame()
+		local scrollFrame = self:createFrame()
 		scrollFrame:setParent(node)
 		scrollFrame.parentDidResize = function()
 			scrollFrame.Width = node.Width
@@ -2367,9 +2366,34 @@ function createUI(system)
 			textSize = "default",
 			sound = "button_1",
 			unfocuses = true, -- unfocused focused node when true
+			color = theme.buttonColor,
+			colorPressed = nil,
+			colorSelected = theme.buttonColorSelected,
+			colorDisabled = theme.buttonColorDisabled,
+			textColor = theme.buttonTextColor,
+			textColorPressed = nil,
+			textColorSelected = theme.buttonTextColorSelected,
+			textColorDisabled = theme.buttonTextColorDisabled,
 		}
 
-		config = conf:merge(defaultConfig, config)
+		local options = {
+			acceptTypes = {
+				colorPressed = { "Color" },
+				textColorPressed = { "Color" },
+			},
+		}
+
+		config = conf:merge(defaultConfig, config, options)
+
+		if config.colorPressed == nil then
+			config.colorPressed = Color(config.color)
+			config.colorPressed:ApplyBrightnessDiff(-0.15)
+		end
+
+		if config.textColorPressed == nil then
+			config.textColorPressed = Color(config.textColor)
+			config.textColorPressed:ApplyBrightnessDiff(-0.15)
+		end
 
 		local theme = require("uitheme").current
 
@@ -2493,10 +2517,10 @@ function createUI(system)
 			end
 		end
 
-		node:setColor(theme.buttonColor, theme.buttonTextColor, true)
-		node:setColorPressed(theme.buttonColorPressed, theme.buttonTextColorPressed, true)
-		node:setColorSelected(theme.buttonColorSelected, theme.buttonTextColorSelected, true)
-		node:setColorDisabled(theme.buttonColorDisabled, theme.buttonTextColorDisabled, true)
+		node:setColor(config.color, config.textColor, true)
+		node:setColorPressed(config.colorPressed, config.textColorPressed, true)
+		node:setColorSelected(config.colorSelected, config.textColorSelected, true)
+		node:setColorDisabled(config.colorDisabled, config.textColorDisabled, true)
 
 		local background = Quad()
 		background.Color = node.colors[1]

--- a/lua/modules/uikit.lua
+++ b/lua/modules/uikit.lua
@@ -283,8 +283,8 @@ function createUI(system)
 			attr.object.LocalPosition.Z = -UI_FAR * 0.45
 		end
 
-		if self.parentDidResize then
-			self:parentDidResize()
+		if self.parentDidResizeWrapper then
+			self:parentDidResizeWrapper()
 		end
 	end
 
@@ -758,8 +758,8 @@ function createUI(system)
 				t:_setWidth(v)
 
 				for _, child in pairs(t.children) do
-					if child.parentDidResize ~= nil then
-						child:parentDidResize()
+					if child.parentDidResizeWrapper ~= nil then
+						child:parentDidResizeWrapper()
 					end
 				end
 
@@ -776,8 +776,8 @@ function createUI(system)
 				t:_setHeight(v)
 
 				for _, child in pairs(t.children) do
-					if child.parentDidResize ~= nil then
-						child:parentDidResize()
+					if child.parentDidResizeWrapper ~= nil then
+						child:parentDidResizeWrapper()
 					end
 				end
 
@@ -931,6 +931,15 @@ function createUI(system)
 				type = NodeType.None,
 				children = {},
 				parentDidResize = nil,
+				parentDidResizeSystem = nil,
+				parentDidResizeWrapper = function(self)
+					if self.parentDidResizeSystem ~= nil then
+						self:parentDidResizeSystem()
+					end
+					if self.parentDidResize ~= nil then
+						self:parentDidResize()
+					end
+				end,
 				contentDidResize = nil, -- user defined
 				contentDidResizeSystem = nil,
 				contentDidResizeWrapper = function(self)
@@ -2912,8 +2921,8 @@ function createUI(system)
 		end
 
 		for _, child in pairs(rootChildren) do
-			if child.parentDidResize ~= nil then
-				child:parentDidResize()
+			if child.parentDidResizeWrapper ~= nil then
+				child:parentDidResizeWrapper()
 			end
 		end
 	end, { system = system == true and System or nil, topPriority = true })

--- a/lua/modules/worlds.lua
+++ b/lua/modules/worlds.lua
@@ -3,24 +3,19 @@ worlds = {}
 worlds.createModalContent = function(_, config)
 	local itemGrid = require("item_grid")
 	local worldDetails = require("world_details")
-	local pages = require("pages")
 	local theme = require("uitheme").current
 	local modal = require("modal")
+	local conf = require("config")
+	local emptyFn = function() end
 
 	-- default config
-	local _config = {
+	local defaultConfig = {
 		uikit = require("uikit"), -- allows to provide specific instance of uikit
 	}
 
-	if config then
-		for k, v in pairs(_config) do
-			if type(config[k]) == type(v) then
-				_config[k] = config[k]
-			end
-		end
-	end
+	config = conf:merge(defaultConfig, config)
 
-	local ui = _config.uikit
+	local ui = config.uikit
 
 	local exploreContent = modal:createContent()
 	exploreContent.title = "Worlds"
@@ -34,7 +29,7 @@ worlds.createModalContent = function(_, config)
 		uikit = ui,
 	})
 
-	pages = pages:create(ui)
+	local pages = require("pages"):create(ui)
 	exploreContent.bottomCenter = { pages }
 
 	exploreContent.tabs = {
@@ -54,16 +49,16 @@ worlds.createModalContent = function(_, config)
 		},
 	}
 
-	grid.onPaginationChange = function(page, nbPages)
+	local onPaginationChange = function(page, nbPages)
 		pages:setNbPages(nbPages)
 		pages:setPage(page)
 	end
+	grid.onPaginationChange = emptyFn
 
-	pages:setPageDidChange(function(page)
-		if grid.setPage ~= nil then
-			grid:setPage(page)
-		end
-	end)
+	local pageDidChange = function(page)
+		grid:setPage(page)
+	end
+	pages:setPageDidChange(emptyFn)
 
 	exploreContent.node = grid
 
@@ -71,23 +66,11 @@ worlds.createModalContent = function(_, config)
 		local grid = content
 		grid.Width = width
 		grid.Height = height
-		if grid.refresh then
-			grid:refresh()
-		end
+		grid:refresh()
 		return Number2(grid.Width, grid.Height)
 	end
 
-	exploreContent.willResignActive = function(_)
-		grid:cancelRequestsAndTimers()
-	end
-
-	exploreContent.didBecomeActive = function(_)
-		if grid.refresh then
-			grid:refresh()
-		end
-	end
-
-	grid.onOpen = function(_, cell)
+	local onOpen = function(_, cell)
 		if cell.type ~= "world" then
 			return
 		end
@@ -118,6 +101,21 @@ worlds.createModalContent = function(_, config)
 		end
 
 		exploreContent:push(worldDetailsContent)
+	end
+	grid.onOpen = emptyFn
+
+	exploreContent.willResignActive = function(_)
+		grid:cancelRequestsAndTimers()
+		grid.onPaginationChange = emptyFn
+		grid.onOpen = emptyFn
+		pages:setPageDidChange(emptyFn)
+	end
+
+	exploreContent.didBecomeActive = function(_)
+		grid.onPaginationChange = onPaginationChange
+		pages:setPageDidChange(pageDidChange)
+		grid.onOpen = onOpen
+		grid:refresh()
 	end
 
 	return exploreContent


### PR DESCRIPTION
- Removed unnecessary `nil` checks used to early return within supposably removed uikit nodes. (checks should be made upstream, same for cancelling requests, timers and listeners)
- Improved friends modal
- fixed ui_container (no more stack overflows)

Fixes CUB-1170
Fixes CUB-1134 (I think it does fix it)
Fixes CUB-1079