### PR TITLE
Signup: auto-lower text input

### DIFF
--- a/lua/modules/signup.lua
+++ b/lua/modules/signup.lua
@@ -306,7 +306,12 @@ signup.createModal = function(_, config)
 		end
 	end
 
-	usernameInput.onTextChange = function(_)
+	usernameInput.onTextChange = function(self)
+		local backup = self.onTextChange
+		self.onTextChange = nil
+		self.Text = string.lower(self.Text)
+		self.onTextChange = backup
+
 		checkUsernameKey = nil
 		checkUsernameError = nil
 		checkUsername()


### PR DESCRIPTION
Using uppercase A-Z characters triggers an error on signup screen saying only a-z characters are allowed. 
It's misleading for some users, according to recent feedback. 

The solution here is to force lowercase characters on input. 
With this PR, typing "Bill" now automatically displays "bill". 

