### PR TITLE
Item Editor: fix undo not available if first action is a long press

### DIFF
--- a/lua/modules/item_editor.lua
+++ b/lua/modules/item_editor.lua
@@ -826,7 +826,11 @@ up = function(_)
 	if shape then
 		shape.KeepHistoryTransactionPending = false
 	end
-	continuousEdition = false
+
+	if continuousEdition then
+		refreshUndoRedoButtons()
+		continuousEdition = false
+	end
 end
 
 Client.OnPlayerJoin = function(_)


### PR DESCRIPTION
Repro,
- Open an item
- Long press to begin continuous edition
- Add/Remove some blocks continuously
- Release long press

Observed: undo button doesn't activate (if long press is the first action of the list of actions)