### PR TITLE
Fix Raycast typo (docs)

### DIFF
--- a/lua/docs/content/cubzhcheatsheet.yml
+++ b/lua/docs/content/cubzhcheatsheet.yml
@@ -178,7 +178,7 @@ blocks:
             local impact = ray:Cast()
 
             if impact.Block ~= nil then
-                local position = pointer.Position + pointerEvent.Direction * impact.Distance
+                local position = pointerEvent.Position + pointerEvent.Direction * impact.Distance
                 print("block hit:", impact.Block)
             end
         end


### PR DESCRIPTION
It looks like there's a small error with the variable pointer that doesn't exist.