### PR TITLE
hide eye lids in first person camera mode

### DIFF
--- a/lua/modules/camera_modes.lua
+++ b/lua/modules/camera_modes.lua
@@ -65,6 +65,8 @@ function showAvatar(entry)
 
 	player.Head.IsHidden = false
 	player.Head.IsHiddenSelf = false
+	player.EyeLidRight.IsHidden = false
+	player.EyeLidLeft.IsHidden = false
 	player.Body.IsHiddenSelf = false
 	player.RightArm.IsHidden = false
 	player.LeftArm.IsHidden = false
@@ -91,6 +93,8 @@ function hideAvatar(entry)
 
 	player.Head.IsHidden = false
 	player.Head.IsHiddenSelf = true
+	player.EyeLidRight.IsHidden = true
+	player.EyeLidLeft.IsHidden = true
 	player.Body.IsHiddenSelf = true
 	player.RightArm.IsHidden = true
 	player.LeftArm.IsHidden = true


### PR DESCRIPTION
Eye blinks have bothering a few devs who're using first person camera mode through `camera_modes` module...
Here's a fix to hide eye lids when in first person. 