### PR TITLE
Windows fix bundle and storage file access

### DIFF
--- a/deps/xptools/include/filesystem.hpp
+++ b/deps/xptools/include/filesystem.hpp
@@ -242,8 +242,11 @@ void removeStorageDirectoryRecurse(std::string dirPath);
 /// Returns true on success, false otherwise.
 bool readFile(const std::string filepath, std::string& dest);
 
-// Returns path without its last element.
+/// Returns path without its last element.
 std::string pathDir(const std::string& path);
+
+/// Normalizes the given path, removing all "." and ".." elements it may contain.
+std::string normalizePath(const std::string &path);
 
 }
 }

--- a/deps/xptools/windows/filesystem_windows.cpp
+++ b/deps/xptools/windows/filesystem_windows.cpp
@@ -246,8 +246,20 @@ FILE *vx::fs::openFile(const std::string& filepath, const std::string& mode) {
 
 /// Use binary mode for non text files
 FILE *vx::fs::openStorageFile(std::string relFilePath, std::string mode, size_t writeSize) {
+
+    // construct the absolute path of the file
     const std::string storagePath = _getAbsStoragePath();
-    std::string absPath = storagePath + "\\" + relFilePath;
+    const std::string absPath = storagePath + "\\" + relFilePath;
+
+    // normalize the path, to remove any . or .. element it may contain
+    const std::string absPathNormalized = vx::fs::normalizePath(absPath);
+
+    // make sure the normalized path targets a file *inside* the storage directory
+    if (vx::str::hasPrefix(absPathNormalized, storagePath) == false) {
+        // don't open files outside of the storage directory
+        return nullptr;
+    }
+
     FILE *fd = nullptr;
 
     // create parent directories if missing when opening for writing


### PR DESCRIPTION
- added `normalizePath` to xptools (`vx::fs`)
- implemented it only for windows (as it is not used elsewhere for now, and later on we might upgrade to C++17 and use the included `filesystem` functions from the standard library)