### PR TITLE
Fix item regressions

### DIFF
--- a/lua/modules/cubzh.lua
+++ b/lua/modules/cubzh.lua
@@ -1133,12 +1133,17 @@ function home()
 
 		local function cellResizeFn(self)
 			self.Width = self.parent.Width
-			self.title.pos = { padding, self.Height - self.title.Height - padding }
+			self.title.pos = { padding * 2, self.Height - self.title.Height - padding }
 
 			if self.scroll then
 				self.scroll.pos = { padding, padding }
 				self.scroll.Height = self.Height - self.title.Height - padding * 3
 				self.scroll.Width = self.Width - padding * 2
+			end
+
+			if self.button then
+				self.button.pos.Y = self.title.pos.Y + self.title.Height * 0.5 - self.button.Height * 0.5
+				self.button.pos.X = self.Width - self.button.Width - padding * 2
 			end
 		end
 
@@ -1661,6 +1666,10 @@ function home()
 			},
 			{
 				title = "🍏 New Items",
+				buttonLabel = "all items",
+				buttonAction = function()
+					Menu:ShowItems()
+				end,
 				cellSize = CONFIG.ITEM_CELL_SIZE,
 				loadCell = function(index, dataFetcher)
 					if index <= dataFetcher.nbEntities then
@@ -1693,6 +1702,10 @@ function home()
 			},
 			{
 				title = "⚔️ Popular Items",
+				buttonLabel = "all items",
+				buttonAction = function()
+					Menu:ShowItems()
+				end,
 				cellSize = CONFIG.ITEM_CELL_SIZE,
 				loadCell = function(index, dataFetcher)
 					if index <= dataFetcher.nbEntities then
@@ -1719,6 +1732,10 @@ function home()
 
 			cell.Height = title.Height + (category.cellSize or 100) + padding * 3 + CONFIG.CELL_PADDING * 2
 			cell.title = title
+
+			cell.button = ui:buttonLink({ content = "", textSize = "small" })
+			cell.button:setParent(cell)
+
 			return cell
 		end
 
@@ -1899,6 +1916,15 @@ function home()
 						categoryCells[categoryIndex] = cell
 
 						cell.title.Text = category.title
+
+						if category.buttonAction then
+							cell.button:show()
+							cell.button.Text = category.buttonLabel or "..."
+							cell.button.onRelease = category.buttonAction
+						else
+							cell.button:hide()
+							cell.button.onRelease = nil
+						end
 
 						if category.loadCell ~= nil then
 							if cell.scroll then

--- a/lua/modules/menu.lua
+++ b/lua/modules/menu.lua
@@ -244,7 +244,7 @@ function showModal(key, config)
 		content = require("world_details"):createModalContent(config)
 		activeModal = modal:create(content, maxModalWidth, maxModalHeight, updateModalPosition, ui)
 	elseif key == MODAL_KEYS.ITEMS then
-		content = require("gallery"):createModalContent({ uikit = ui })
+		content = require("gallery"):createModalContent({ uikit = ui, type = "items", perPage = 100 })
 		activeModal = modal:create(content, maxModalWidth, maxModalHeight, updateModalPosition, ui)
 	elseif key == MODAL_KEYS.ITEM then
 		local config = config or {}

--- a/lua/modules/menu.lua
+++ b/lua/modules/menu.lua
@@ -40,7 +40,7 @@ PADDING = theme.padding
 PADDING_BIG = 9
 TOP_BAR_HEIGHT = 40
 
--- CUBZH_MENU_MAIN_BUTTON_HEIGHT = 60
+CUBZH_MENU_MAIN_BUTTON_HEIGHT = 60
 CUBZH_MENU_SECONDARY_BUTTON_HEIGHT = 40
 
 -- VARS
@@ -1089,6 +1089,8 @@ refreshChat()
 -- CUBZH MENU CONTENT
 
 function getCubzhMenuModalContent()
+	local dev = System.LocalUserIsAuthor and System.ServerIsInDevMode
+
 	local content = modal:createContent()
 	content.closeButton = true
 	content.title = "Cubzh"
@@ -1097,9 +1099,23 @@ function getCubzhMenuModalContent()
 	local node = ui:createFrame()
 	content.node = node
 
+	local btnItems
+	if dev then
+		btnItems = ui:buttonNeutral({ content = "Items", textSize = "default" })
+		btnItems:setParent(node)
+		btnItems.Height = CUBZH_MENU_SECONDARY_BUTTON_HEIGHT
+
+		btnItems.onRelease = function()
+			if activeModal ~= nil then
+				local content = require("gallery"):createModalContent({ uikit = ui, type = "items", perPage = 100 })
+				activeModal:push(content)
+			end
+		end
+	end
+
 	local btnLeave = ui:buttonNegative({ content = "Leave", textSize = "default" })
 	btnLeave:setParent(node)
-	btnLeave.Height = CUBZH_MENU_SECONDARY_BUTTON_HEIGHT
+	btnLeave.Height = CUBZH_MENU_MAIN_BUTTON_HEIGHT
 
 	btnLeave.onRelease = function()
 		System:GoHome()
@@ -1107,7 +1123,6 @@ function getCubzhMenuModalContent()
 
 	local buttons
 
-	local dev = System.LocalUserIsAuthor and System.ServerIsInDevMode
 	local btnCode = ui:buttonSecondary({
 		content = dev and "🤓 Edit Code" or "🤓 Read Code",
 		textSize = "small",
@@ -1133,9 +1148,16 @@ function getCubzhMenuModalContent()
 		URL:Open("https://discord.gg/cubzh")
 	end
 
-	buttons = {
-		{ btnLeave },
-	}
+	if dev then
+		buttons = {
+			{ btnItems },
+			{ btnLeave },
+		}
+	else
+		buttons = {
+			{ btnLeave },
+		}
+	end
 
 	content.bottomCenter = { btnCode, btnHelp }
 


### PR DESCRIPTION
This PR fixes a few regressions for items. 
Fixes #613

- Adds "all items" button on item rows to browse all items: 
    <img width="693" alt="Screenshot 2024-08-13 at 19 03 47" src="https://github.com/user-attachments/assets/04751351-0b8f-4b55-9992-d4a6e16b0e03">
- Adds "Items" button on pause menu when in dev mode: 
    <img width="802" alt="Screenshot 2024-08-13 at 19 03 13" src="https://github.com/user-attachments/assets/fbb0da8d-5173-470b-bd3a-c57c83446c14">
    <img width="802" alt="Screenshot 2024-08-13 at 19 03 29" src="https://github.com/user-attachments/assets/7b339d0c-c891-4ab2-8d9c-c5f4de2d4724">
- Adds button to edit item description:
    <img width="447" alt="Screenshot 2024-08-13 at 19 16 30" src="https://github.com/user-attachments/assets/24d86061-eac1-461e-97de-de926060e357">


