### PR TITLE
Fix memory leaks

### DIFF
--- a/core/shape.c
+++ b/core/shape.c
@@ -4274,6 +4274,9 @@ bool _shape_compute_size_and_origin(const Shape *shape,
                                     SHAPE_COORDS_INT_T *origin_z) {
 
     Index3DIterator *it = index3d_iterator_new(shape->chunks);
+    if (it == NULL) {
+        return false;
+    }
     if (index3d_iterator_pointer(it) == NULL) {
         *size_x = 0;
         *size_y = 0;
@@ -4281,6 +4284,7 @@ bool _shape_compute_size_and_origin(const Shape *shape,
         *origin_x = 0;
         *origin_y = 0;
         *origin_z = 0;
+        index3d_iterator_free(it);
         return false; // empty shape
     }
 

--- a/deps/xptools/common/HttpCookie.cpp
+++ b/deps/xptools/common/HttpCookie.cpp
@@ -164,7 +164,7 @@ bool CookieStore::saveToDisk() {
         // create JSON representation of the cookie
         cJSON *obj = cJSON_CreateObject();
         if (obj == nullptr) {
-            cJSON_free(arr);
+            cJSON_Delete(arr);
             return false;
         }
         vx::json::writeStringField(obj, _domainFieldName, c.getDomain());
@@ -178,7 +178,7 @@ bool CookieStore::saveToDisk() {
 
     // generate JSON string and free JSON resources
     char *jsonCStr = cJSON_Print(arr);
-    cJSON_free(arr);
+    cJSON_Delete(arr);
     arr = nullptr;
 
     if (jsonCStr == nullptr) {
@@ -229,7 +229,7 @@ bool CookieStore::_loadFromDisk() {
         return false;
     }
     if (cJSON_IsArray(arr) == false) {
-        cJSON_free(arr);
+        cJSON_Delete(arr);
         return false;
     }
 
@@ -263,7 +263,7 @@ bool CookieStore::_loadFromDisk() {
         _cookies.insert(c);
     }
 
-    cJSON_free(arr);
+    cJSON_Delete(arr);
     return true;
 }
 


### PR DESCRIPTION
- Fixes memory leaks in `HttpCookie.cpp` (⚠️ `cJSON_Delete` vs `cJSON_free`)
- Fixes memory leak in `_shape_compute_size_and_origin` (iterator not freed in early return condition)