### PR TITLE
fix listing of friend requests by users without username

### DIFF
--- a/lua/modules/friends.lua
+++ b/lua/modules/friends.lua
@@ -209,11 +209,12 @@ mt.__index.create = function(_, maxWidth, maxHeight, position, uikit)
 					return
 				end
 				for _, usr in ipairs(users) do
-					if usr.username ~= "" then
-						-- if search, match the username
-						if not searchText or string.find(usr.username, searchText) then
-							table.insert(list, usr)
-						end
+					-- if search, match the username
+					if usr.username == "" then
+						usr.username = Players.DefaultUsername
+					end
+					if not searchText or string.find(usr.username, searchText) then
+						table.insert(list, usr)
 					end
 				end
 				newListResponse(listID, list)


### PR DESCRIPTION
fixes #641 

I just removed this condition: `if usr.username ~= "" then`

## BEFORE

<img width="995" alt="Screenshot 2024-09-08 at 16 24 47" src="https://github.com/user-attachments/assets/25ef0a9d-2111-409c-8735-5d46da9afaa3">

## AFTER

<img width="995" alt="Screenshot 2024-09-08 at 16 25 55" src="https://github.com/user-attachments/assets/ad87183a-c539-4d27-88b3-f28425279daa">
