### PR TITLE
doc: show all sounds on adding-sounds page

### DIFF
--- a/lua/docs/Dockerfile
+++ b/lua/docs/Dockerfile
@@ -1,3 +1,17 @@
+FROM alpine:3.20 AS audio-converter
+
+RUN apk update && apk add --no-cache \
+	ffmpeg \
+	&& rm -rf /var/cache/apk/*
+
+COPY ./bundle/audio /audio_input
+RUN mkdir /audio_output
+
+# WORKDIR /audio_input
+RUN find /audio_input -name '*.ogg' -exec sh -c 'ffmpeg -i "$1" "/audio_output/$(basename "${1%.ogg}.mp3")"' _ {} \;
+
+#################################
+
 FROM --platform=linux/amd64 golang:1.23.2-alpine3.20 AS build-env
 
 RUN apk update && apk add --no-cache \
@@ -9,6 +23,7 @@ COPY ./lua/docs/webserver /webserver
 COPY ./lua/docs/content /www
 COPY ./lua/docs/parser /parser
 COPY ./lua/modules /modules
+COPY --from=audio-converter /audio_output /www/audio
 
 RUN cd /parser && ./parse.sh
 

--- a/lua/docs/content/audio/440hz.mp3
+++ b/lua/docs/content/audio/440hz.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b51cd5dac8da2ae3b7ba17216e0c291077253e531c62e79597203f2e6f06ed9d
-size 8586

--- a/lua/docs/content/audio/big_explosion_1.mp3
+++ b/lua/docs/content/audio/big_explosion_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6cf712e15e8c1815397e1233726b397d5c4f9d736d700c0f8c1216e4ac1171b
-size 47153

--- a/lua/docs/content/audio/big_explosion_2.mp3
+++ b/lua/docs/content/audio/big_explosion_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bad1bd42eccbfe18a7aed601186d9713b2a9250189ba427707925d30eb916e72
-size 40630

--- a/lua/docs/content/audio/big_explosion_3.mp3
+++ b/lua/docs/content/audio/big_explosion_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c32ec2348def2d4442a53104285175c88a0428daf24a0eeb8e1bd45fdd1a471b
-size 40630

--- a/lua/docs/content/audio/broken_glass_1.mp3
+++ b/lua/docs/content/audio/broken_glass_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b0d3f9a7bca98b0ffea2ee0e299f0a6ae2452e12ee37b7616529275b042b88a
-size 12593

--- a/lua/docs/content/audio/broken_glass_2.mp3
+++ b/lua/docs/content/audio/broken_glass_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7463285dee556fd364f105957aa7656674275e097461e23b774d4c97bfde6e2a
-size 12597

--- a/lua/docs/content/audio/broken_glass_3.mp3
+++ b/lua/docs/content/audio/broken_glass_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93cb214873cfc1df99b91b5585a3fe09ed4d4285f1b0fa1d676c7b2adab4b374
-size 12598

--- a/lua/docs/content/audio/broken_glass_4.mp3
+++ b/lua/docs/content/audio/broken_glass_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:059b3b01d45884a7c6c5210ed4ebc9b4a160edf216a18115c6b43033d584b5c5
-size 12598

--- a/lua/docs/content/audio/broken_glass_5.mp3
+++ b/lua/docs/content/audio/broken_glass_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00029d3b1ed201b4102208ca81fc6c69298ec6f42e137a948f839aee9d5922e2
-size 12598

--- a/lua/docs/content/audio/death_scream_guy_1.mp3
+++ b/lua/docs/content/audio/death_scream_guy_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc4985255e2f033513860463ca9119f0249a96eb0879999879a8957be748bb4f
-size 13361

--- a/lua/docs/content/audio/death_scream_guy_2.mp3
+++ b/lua/docs/content/audio/death_scream_guy_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b36d482efeb2d1fde70b7de274baa3650412aa4fcc9b75a90432e01b5f6ad362
-size 13365

--- a/lua/docs/content/audio/death_scream_guy_3.mp3
+++ b/lua/docs/content/audio/death_scream_guy_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02435273f0d6a6e56a86a8c896a2b8fc28eb820386c9d3ce2125ca7486e8ccd8
-size 11829

--- a/lua/docs/content/audio/death_scream_guy_4.mp3
+++ b/lua/docs/content/audio/death_scream_guy_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39ea19676395e4f0864195ed9082bfd944e72e7980f29959b5a85e415b3f7bad
-size 10678

--- a/lua/docs/content/audio/death_scream_guy_5.mp3
+++ b/lua/docs/content/audio/death_scream_guy_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c486d5d4e9520682a31bb1ef505ab9373e333745f2a605776e714adabc78a2d
-size 9142

--- a/lua/docs/content/audio/death_scream_lady_1.mp3
+++ b/lua/docs/content/audio/death_scream_lady_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4940fd10e36ae9f209b7ab2048a382a593c58a71c08912a9eeb44b796b8111f3
-size 7601

--- a/lua/docs/content/audio/death_scream_lady_2.mp3
+++ b/lua/docs/content/audio/death_scream_lady_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa751b2512f5dfb193c2ed925ec3098a7b816afe303edfdaa8eae4629d556a52
-size 7605

--- a/lua/docs/content/audio/death_scream_lady_3.mp3
+++ b/lua/docs/content/audio/death_scream_lady_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b48e781feade8f6cc0411f0e096f1f001d0eca59ac447ba3f4dab376cd0cc909
-size 7605

--- a/lua/docs/content/audio/death_scream_lady_4.mp3
+++ b/lua/docs/content/audio/death_scream_lady_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4aed8d8f2aec3255225902f0de59e3d5a9f4ff2221e750ee8d0b8b7ea9c7b218
-size 7606

--- a/lua/docs/content/audio/death_scream_lady_5.mp3
+++ b/lua/docs/content/audio/death_scream_lady_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:532602cd853f919ef71c754b1b492f2bcfefb432807968fcf28b1295767ee31b
-size 7606

--- a/lua/docs/content/audio/drinking_1.mp3
+++ b/lua/docs/content/audio/drinking_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c8e360686148eb99ccb22027809474a4dc6ce438ca04aa067f23c5d7191281c
-size 3377

--- a/lua/docs/content/audio/drinking_2.mp3
+++ b/lua/docs/content/audio/drinking_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec3048b03f9d94c09dbf8238816b1d2749607bd02045b7695ce96688ac875717
-size 3381

--- a/lua/docs/content/audio/drinking_3.mp3
+++ b/lua/docs/content/audio/drinking_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76857629be4301b23db1625eeba511ed0fd9c853651143ec1c8b152ce507be72
-size 3381

--- a/lua/docs/content/audio/eating_1.mp3
+++ b/lua/docs/content/audio/eating_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d8e9f6d3993d1b6ffe08b1076a1434b8d820c853cbe35c4acd914606d18ca01
-size 8369

--- a/lua/docs/content/audio/eating_2.mp3
+++ b/lua/docs/content/audio/eating_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d85e0e11b57311f58caec92fe6c887d148d9fa25a4d11b502650c05c0f641947
-size 6069

--- a/lua/docs/content/audio/eating_3.mp3
+++ b/lua/docs/content/audio/eating_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7b7e54aaa1d81ffbb57c5d1fa1394ad71d07fd33d61a9c2dd825dda52818a12
-size 4533

--- a/lua/docs/content/audio/eating_4.mp3
+++ b/lua/docs/content/audio/eating_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:355b91a53772e1e084af439373a5deb7ed8a5ddcf1ced12b530fd94341f38936
-size 4533

--- a/lua/docs/content/audio/eating_5.mp3
+++ b/lua/docs/content/audio/eating_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4586e61da0d2cc3cc5b4c9b382a59d13d5f5157781afbc7420517bbe016c5dd9
-size 4150

--- a/lua/docs/content/audio/fireworks_fireworks — child_1.mp3
+++ b/lua/docs/content/audio/fireworks_fireworks — child_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43fa836da588e8ace089558945448f84276d84dc94db602ea05c1339449a8c20
-size 61361

--- a/lua/docs/content/audio/fireworks_fireworks — child_2.mp3
+++ b/lua/docs/content/audio/fireworks_fireworks — child_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03b10853eb1c7c18a82c63a8f71a20a59023fc43ab67f0603aa91fef8013765e
-size 57526

--- a/lua/docs/content/audio/fireworks_fireworks — child_3.mp3
+++ b/lua/docs/content/audio/fireworks_fireworks — child_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88b2a6b44c556bc808ab8d0a7652d9c23e10d8a2cebebd9567f843bd99d03fdd
-size 58294

--- a/lua/docs/content/audio/ground_digging_1.mp3
+++ b/lua/docs/content/audio/ground_digging_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a417515e0ce167e39a19936e8aee304dca5a8be89a3933bc4d898b4ba13d633
-size 6449

--- a/lua/docs/content/audio/ground_digging_2.mp3
+++ b/lua/docs/content/audio/ground_digging_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e62805577247f3ebc886e5013af4b827a39b2c4833a0c4a30911d75e5d48c727
-size 6837

--- a/lua/docs/content/audio/ground_digging_3.mp3
+++ b/lua/docs/content/audio/ground_digging_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04f6ff8bf72d51b8e44ac2c78a13887d0adbcd96d28bb2cc0f9da238d65566bb
-size 5685

--- a/lua/docs/content/audio/gun_reload_1.mp3
+++ b/lua/docs/content/audio/gun_reload_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f0a1d48f0780e860f28cc514d4da044bd147bd67d217b4e0115065aa3ab22b5
-size 4529

--- a/lua/docs/content/audio/gun_reload_2.mp3
+++ b/lua/docs/content/audio/gun_reload_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14ccc894bd643851e5fd6380d9fa056ad581424a3308adc0d7020e514776b871
-size 4533

--- a/lua/docs/content/audio/gun_reload_3.mp3
+++ b/lua/docs/content/audio/gun_reload_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11c3dbe3b28c676bdc183f341ad282fde677cbb24188569cf14c26e9458c28a7
-size 4533

--- a/lua/docs/content/audio/gun_shot_1.mp3
+++ b/lua/docs/content/audio/gun_shot_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f985d62b7b87ba08a55d01ff5a32229bd1debe459e2f1be4374f8ec6b9e61e9
-size 6065

--- a/lua/docs/content/audio/gun_shot_2.mp3
+++ b/lua/docs/content/audio/gun_shot_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d59a9cd2bb26f9c43a07b10a33b2916193ff7ea980d4ca4b1ed5c42f32141a86
-size 6069

--- a/lua/docs/content/audio/hurt_scream_female_1.mp3
+++ b/lua/docs/content/audio/hurt_scream_female_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a19cf926adfa9c2c53b8bee58178671253a0b947cff339609bb6adbe2c04c794
-size 4145

--- a/lua/docs/content/audio/hurt_scream_female_2.mp3
+++ b/lua/docs/content/audio/hurt_scream_female_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6ae29e7b38b689442155b59d53d4ead1e3a8248d459774927a2ff1a4c12e61f
-size 4149

--- a/lua/docs/content/audio/hurt_scream_female_3.mp3
+++ b/lua/docs/content/audio/hurt_scream_female_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f55dc5e007e712bdf0215f8672344a7cf617fcbf3801d524cfede8d7ce1fb42b
-size 4149

--- a/lua/docs/content/audio/hurt_scream_female_4.mp3
+++ b/lua/docs/content/audio/hurt_scream_female_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:607e37dfef57c01ce0546b08e3aa6d4766c6e976592098105ead37d7412e4260
-size 4149

--- a/lua/docs/content/audio/hurt_scream_female_5.mp3
+++ b/lua/docs/content/audio/hurt_scream_female_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a5466b681fc17d298a90d9242d436c995a798488311b1f09131e0b88da6b97d
-size 4149

--- a/lua/docs/content/audio/hurt_scream_male_1.mp3
+++ b/lua/docs/content/audio/hurt_scream_male_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6385fe00cdd79daed91c306d9e91ae80eadd0079b46c21d9f8503993d02e445b
-size 4145

--- a/lua/docs/content/audio/hurt_scream_male_2.mp3
+++ b/lua/docs/content/audio/hurt_scream_male_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:175affa16e8bef20541da97c898d67c45e7e94d947b1ba3505271e763ff69771
-size 4149

--- a/lua/docs/content/audio/hurt_scream_male_3.mp3
+++ b/lua/docs/content/audio/hurt_scream_male_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:062b1faf392f4f39cfdf259427682a2cc7c3fdefea1c86d211e0b5e5fc49f58a
-size 4149

--- a/lua/docs/content/audio/hurt_scream_male_4.mp3
+++ b/lua/docs/content/audio/hurt_scream_male_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:154f2150b95ecf6cee4368bd61aec1a594229545627d496c70d9f6e975be5a5f
-size 4149

--- a/lua/docs/content/audio/hurt_scream_male_5.mp3
+++ b/lua/docs/content/audio/hurt_scream_male_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5e7694b07cb47a5e6aee7dff8e223023d94eadee13a598fae851d63a4676c98
-size 4149

--- a/lua/docs/content/audio/laser_gun_shot_1.mp3
+++ b/lua/docs/content/audio/laser_gun_shot_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6afd2a6a502cb7470f675dba8086bf58ba62a3279edc1e2b26e497e9b730818
-size 15281

--- a/lua/docs/content/audio/metal_clanging_1.mp3
+++ b/lua/docs/content/audio/metal_clanging_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86e5e89fea60591fe4a04f2bb3054200d5977fa297de2d1ae3ded213d8666fa0
-size 9137

--- a/lua/docs/content/audio/metal_clanging_2.mp3
+++ b/lua/docs/content/audio/metal_clanging_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd9dae9116269ecc5d228881ae9046c47c047aff3ec8508058e1f8ab1fe67772
-size 9141

--- a/lua/docs/content/audio/metal_clanging_3.mp3
+++ b/lua/docs/content/audio/metal_clanging_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0fef9322d3e95adb3ebdd125ede39730b1f46d956db19a640aebf74b95e1cf88
-size 9141

--- a/lua/docs/content/audio/metal_clanging_4.mp3
+++ b/lua/docs/content/audio/metal_clanging_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64c02aa2eceeac6e3738ed7ed79b0a55f716f647dac7ae92b11f0a63f7f08a7c
-size 9142

--- a/lua/docs/content/audio/metal_clanging_5.mp3
+++ b/lua/docs/content/audio/metal_clanging_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f82804db07f73e186ea0acd99b538ebad5c94aefc2345133f90ea6035b42846
-size 9142

--- a/lua/docs/content/audio/metal_clanging_6.mp3
+++ b/lua/docs/content/audio/metal_clanging_6.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bc6cb1935567e750da656f67c9e974341a39590e75046a86647b1df10a2d77a
-size 9142

--- a/lua/docs/content/audio/metal_clanging_7.mp3
+++ b/lua/docs/content/audio/metal_clanging_7.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:644259045c4c5db2e3d5e7bf1d68b64a0fbecdb4052e292bf528c94b1c54a2cd
-size 9142

--- a/lua/docs/content/audio/metal_clanging_8.mp3
+++ b/lua/docs/content/audio/metal_clanging_8.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1783ba9673560dcbf65139a3109c3cb294faa9b346ac743e42e521d9fdd78094
-size 9142

--- a/lua/docs/content/audio/punch_1.mp3
+++ b/lua/docs/content/audio/punch_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:362c359599583d7d17d5716c9ae773cf6b0bf48c0aa3e8d58de41ee82d810de5
-size 5681

--- a/lua/docs/content/audio/punch_2.mp3
+++ b/lua/docs/content/audio/punch_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7068a9a4ba663dc4e8431d2ec0d12c3e1dcf1f0a5bcedd3c64b3f8f120a588bc
-size 5685

--- a/lua/docs/content/audio/rain_1.mp3
+++ b/lua/docs/content/audio/rain_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4447f08079f6622c0cc94900fa221c8be6958e76cd3a1757821c4c613cb46265
-size 180789

--- a/lua/docs/content/audio/rain_2.mp3
+++ b/lua/docs/content/audio/rain_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80374d421ad671e77cfc1aa22163a861856a6acf850a2bce5a97dce33912745f
-size 156598

--- a/lua/docs/content/audio/rain_3.mp3
+++ b/lua/docs/content/audio/rain_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91f2360ac1fa3926047827e0332404055a08372234fbb38d5018560a9d0684e3
-size 159671

--- a/lua/docs/content/audio/river_1.mp3
+++ b/lua/docs/content/audio/river_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd37da62ee049f85ed52ab5cdb142b235b943f7ac1244620cddaa4a3d73c5f1f
-size 136241

--- a/lua/docs/content/audio/small_explosion_1.mp3
+++ b/lua/docs/content/audio/small_explosion_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a37079f6ac76d6000c0c05fb38322de2cf8866a6e65705dc00ad7c8185a8df3b
-size 16433

--- a/lua/docs/content/audio/small_explosion_2.mp3
+++ b/lua/docs/content/audio/small_explosion_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d839d4ce626a5a41a8b2a4e05ac85b1d09b1e3b19cea3e4c6d1aae9adf39ce43
-size 16437

--- a/lua/docs/content/audio/small_explosion_3.mp3
+++ b/lua/docs/content/audio/small_explosion_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e59e1f5ea20bd106509774b0cbfc4a13059033b9e0fcc244d520fc0983c7deb0
-size 16438

--- a/lua/docs/content/audio/sword_impact_1.mp3
+++ b/lua/docs/content/audio/sword_impact_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97bdea66b8757198da1827c999ce0ef4fc31671d01a813170c53390535deaa74
-size 8753

--- a/lua/docs/content/audio/sword_impact_2.mp3
+++ b/lua/docs/content/audio/sword_impact_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c0e0addc068e0700718168be813adf7ee788a2345f999120fa79f271eca0f69
-size 8757

--- a/lua/docs/content/audio/sword_impact_3.mp3
+++ b/lua/docs/content/audio/sword_impact_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0ebef5868e6fec5c2019323cfc9120151957a49b24c1d81ebdb954b9fbe3eef
-size 8757

--- a/lua/docs/content/audio/sword_impact_4.mp3
+++ b/lua/docs/content/audio/sword_impact_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a55dbab8a97c784da7f8d6bf4102e77b1d592c31289196e5b00a1c56316f459
-size 8758

--- a/lua/docs/content/audio/sword_impact_5.mp3
+++ b/lua/docs/content/audio/sword_impact_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a37ad905d70d725179c960e30ccf47b14550a74ccbd1ae798a85f51f00a18eaa
-size 8758

--- a/lua/docs/content/audio/sword_impact_6.mp3
+++ b/lua/docs/content/audio/sword_impact_6.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6076ec2060b7593442e24026a9cee2d78e90ab9ac432b34e563d0f92cdb29688
-size 8758

--- a/lua/docs/content/audio/sword_impact_alt_1.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b73c0ad765cfe5b0bdbb9891456a392f9330d3b92f8f52dd5f046554762bb3d
-size 10673

--- a/lua/docs/content/audio/sword_impact_alt_2.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ffad70699d88206a2eb6958024d0bb3dbc4665eea162978ee5ff2638336c6bf
-size 10677

--- a/lua/docs/content/audio/sword_impact_alt_3.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dde660f71d73d6fd4ed4e3c237b1f03f186f3fa6fbcf8e7c1ff757943771ba1f
-size 10293

--- a/lua/docs/content/audio/sword_impact_alt_4.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f5649a0e18a6d48d14ead6f432aaedccc8f079d7528a5670756aa8f92480f9b
-size 10293

--- a/lua/docs/content/audio/sword_impact_alt_5.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ca97b4f0d0b13dfa92ab8cf8766d7e11714b69dba44caa0599d8d74652bc8dc
-size 10294

--- a/lua/docs/content/audio/sword_impact_alt_6.mp3
+++ b/lua/docs/content/audio/sword_impact_alt_6.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c7fa116a86bb5ad73f591401620537a03e0411d341d2e5ed9fea4b5251c8ece
-size 10678

--- a/lua/docs/content/audio/thunder_1.mp3
+++ b/lua/docs/content/audio/thunder_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c58d2dde6fb2ff314c43d82cb61433f6ae8aaf8e868bf4931304c8ef35135e47
-size 89393

--- a/lua/docs/content/audio/thunder_2.mp3
+++ b/lua/docs/content/audio/thunder_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae9e2448910041d246e2e90d1806d1e95eebeb575b1c77d48bce3987837398f7
-size 84406

--- a/lua/docs/content/audio/thunder_3.mp3
+++ b/lua/docs/content/audio/thunder_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9da7f6ec7e0dd7ef18e549528dc8d630d47b13d46f0a0063584881854f6fdc4c
-size 91318

--- a/lua/docs/content/audio/twang_1.mp3
+++ b/lua/docs/content/audio/twang_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eeac457e3d90ca3b5cd7002706f9eca6569ae86ed7dc17adcd7b48cb0f60ad89
-size 5297

--- a/lua/docs/content/audio/twang_2.mp3
+++ b/lua/docs/content/audio/twang_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5a10b90924807c9e4bac6a080dfa1de2ad4ddfae5b9e6694543c176a8705613
-size 4917

--- a/lua/docs/content/audio/twang_3.mp3
+++ b/lua/docs/content/audio/twang_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7517029fffc872c93c0a3a8a2cc4cfe6bcba5e19120fdc71226f7f326487e6b2
-size 4917

--- a/lua/docs/content/audio/twang_4.mp3
+++ b/lua/docs/content/audio/twang_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:979b721d3064c930bc9d52dc7a8919c0fa43e82c3a2335094bd183e83f1aba37
-size 4917

--- a/lua/docs/content/audio/walk_concrete_1.mp3
+++ b/lua/docs/content/audio/walk_concrete_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f1e990de373d307ef93e06d1c3dc6bd00a46e89f537467064a6318b1111c682
-size 4145

--- a/lua/docs/content/audio/walk_concrete_2.mp3
+++ b/lua/docs/content/audio/walk_concrete_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1516a3faf9dd8af0cb91374f097db96a7e915828268ba38ec3c931da452dfa9c
-size 4149

--- a/lua/docs/content/audio/walk_concrete_3.mp3
+++ b/lua/docs/content/audio/walk_concrete_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7300a581e16b5b06a3b5e302a475c865a695c3a6a69fb0bcd08ebaa2566b63b
-size 4149

--- a/lua/docs/content/audio/walk_concrete_4.mp3
+++ b/lua/docs/content/audio/walk_concrete_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a6ebf901af26eaf89ab1f910a274c3a9dcfa4ff1a9909c45b4eeb548ad1ccb5
-size 4149

--- a/lua/docs/content/audio/walk_concrete_5.mp3
+++ b/lua/docs/content/audio/walk_concrete_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:826ad75561d663b6bbae07b0899ba1b738a2044fd272ab716b4bc39fb0635de7
-size 4149

--- a/lua/docs/content/audio/walk_grass_1.mp3
+++ b/lua/docs/content/audio/walk_grass_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c448639f60ab4f048e358c5ba13e23168c79734c0c143066ae00678a8576ba1
-size 3761

--- a/lua/docs/content/audio/walk_grass_2.mp3
+++ b/lua/docs/content/audio/walk_grass_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58a662c9b6b4e20c056ae3166b67e50dade3e5395039048f9137321503bc800f
-size 3765

--- a/lua/docs/content/audio/walk_grass_3.mp3
+++ b/lua/docs/content/audio/walk_grass_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:967d99d4e9e23ce04425548a71fd0e3c757ced8a77448526d8f8b23797f3800a
-size 3765

--- a/lua/docs/content/audio/walk_grass_4.mp3
+++ b/lua/docs/content/audio/walk_grass_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05d721ac59916a5b82569c896975c97f5ed7167344768bfde2ac8b9ab06ac241
-size 3381

--- a/lua/docs/content/audio/walk_grass_5.mp3
+++ b/lua/docs/content/audio/walk_grass_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd2a841beebb8197e6912aeeffe582a42b0b17332d9f34be35bc63ae36ed7d4f
-size 2997

--- a/lua/docs/content/audio/walk_gravel_1.mp3
+++ b/lua/docs/content/audio/walk_gravel_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14ad13ad57038f17b621d7ef396c1f45534aa820c719ac97cad0440f26a65428
-size 4145

--- a/lua/docs/content/audio/walk_gravel_2.mp3
+++ b/lua/docs/content/audio/walk_gravel_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ca3cbaf0c9baefa34efbfa62bdb645951c10191855883f560eb12d84a21046a
-size 4149

--- a/lua/docs/content/audio/walk_gravel_3.mp3
+++ b/lua/docs/content/audio/walk_gravel_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81e4025e16aa897a63cbfd5c3a6b5eaf7be4d1038bb72698f27a7da8dd6513cb
-size 4149

--- a/lua/docs/content/audio/walk_gravel_4.mp3
+++ b/lua/docs/content/audio/walk_gravel_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae54780399a157c703b0430a74c66d4670e0b7a56b8326909ff90347d48209ee
-size 4149

--- a/lua/docs/content/audio/walk_gravel_5.mp3
+++ b/lua/docs/content/audio/walk_gravel_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc596281a5b1a644c1cebf9dfcac1068c3fc8d44132a596385505aaa5ba38653
-size 4149

--- a/lua/docs/content/audio/walk_sand_1.mp3
+++ b/lua/docs/content/audio/walk_sand_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af5847b124b3ab849cde757a32fe8ca901954f3ec85e5765f40100f7f45ff60e
-size 5681

--- a/lua/docs/content/audio/walk_sand_2.mp3
+++ b/lua/docs/content/audio/walk_sand_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3a86e6843035afad443e550e2fe49efc143674bd02365fe5e01eed5ef7ebaed
-size 5685

--- a/lua/docs/content/audio/walk_sand_3.mp3
+++ b/lua/docs/content/audio/walk_sand_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a86a89ee393a920463e0249486acef1f853256bfb2b6e3a1504079a15ab6f275
-size 5685

--- a/lua/docs/content/audio/walk_sand_4.mp3
+++ b/lua/docs/content/audio/walk_sand_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7240a4bd4f02bc812c37d81e5ad469de0e6d3a8013c80163c9d56869b6654e1
-size 5685

--- a/lua/docs/content/audio/walk_sand_5.mp3
+++ b/lua/docs/content/audio/walk_sand_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f28d261d69a95bbde387efee094dc0e7e002b212e027bf027bd1482a39ff36d
-size 5685

--- a/lua/docs/content/audio/walk_snow_1.mp3
+++ b/lua/docs/content/audio/walk_snow_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c431876a6c877d5947472536ab186430f6d6bf23631308bd2fe026d858ca31d0
-size 4145

--- a/lua/docs/content/audio/walk_snow_2.mp3
+++ b/lua/docs/content/audio/walk_snow_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:985c7f125097f32a3d0d1ad230cfa9803b4f919bab039ace622785f8a109185d
-size 4149

--- a/lua/docs/content/audio/walk_snow_3.mp3
+++ b/lua/docs/content/audio/walk_snow_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dca7d7654eba29a179ab5d76f7b677823cb95c56c445072a3086d21bd584d1d
-size 4149

--- a/lua/docs/content/audio/walk_snow_4.mp3
+++ b/lua/docs/content/audio/walk_snow_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef9f65504a9c12483b05fc61bf34c2fcf94bb98f1c2a369dcd0c77e01665762f
-size 4149

--- a/lua/docs/content/audio/walk_snow_5.mp3
+++ b/lua/docs/content/audio/walk_snow_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7e03eddc04a78e110cbcbe19814bade59dde067568d83df3727f3905eb34994
-size 4149

--- a/lua/docs/content/audio/walk_wood_1.mp3
+++ b/lua/docs/content/audio/walk_wood_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e102bd39feea570f625dd0ec5bb6be68ef057c0e98e0c58292b32ec475d3f11
-size 4145

--- a/lua/docs/content/audio/walk_wood_2.mp3
+++ b/lua/docs/content/audio/walk_wood_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6c518438301c005140fe89c3674492ba7baf35372bffa064799aa381bbe4463
-size 4149

--- a/lua/docs/content/audio/walk_wood_3.mp3
+++ b/lua/docs/content/audio/walk_wood_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a34aacfb0f7277c8894acda171be49557f8e7d5f56d2ab008558c6ab753d4fe
-size 4149

--- a/lua/docs/content/audio/walk_wood_4.mp3
+++ b/lua/docs/content/audio/walk_wood_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0fe95f52849a9b1b9733e503861d9ddd8a9ccb255726bc4173e279034be1a66
-size 4149

--- a/lua/docs/content/audio/walk_wood_5.mp3
+++ b/lua/docs/content/audio/walk_wood_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99fb7a5bde4443db35139fe76c21706b4fe7b6b07dace998250d6d6d05536b81
-size 4149

--- a/lua/docs/content/audio/water_impact_1.mp3
+++ b/lua/docs/content/audio/water_impact_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1d8fee4805c2c120afcf2bafb230a7e72f0b54f2aaf2fb4d6ef05177ac1318e
-size 12593

--- a/lua/docs/content/audio/water_impact_2.mp3
+++ b/lua/docs/content/audio/water_impact_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73c3f86ca00dde423431c54a045a129e8236ade072d819c3d469155035c0ff25
-size 12597

--- a/lua/docs/content/audio/water_impact_3.mp3
+++ b/lua/docs/content/audio/water_impact_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47b7e246aeee748f315fac732627622300f66608500d2750414d7ebfb8fe4d79
-size 12598

--- a/lua/docs/content/audio/waterdrop_1.mp3
+++ b/lua/docs/content/audio/waterdrop_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ecaffaca9a97964b304d33e2abe1b0fa0958ffd69a9f12ad58a98a06a125da0
-size 4529

--- a/lua/docs/content/audio/waterdrop_2.mp3
+++ b/lua/docs/content/audio/waterdrop_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ef2476a42c9242b717ca9a9de7d896003782e89dddc298fdd3f25ef94e8dc6e
-size 4533

--- a/lua/docs/content/audio/waterdrop_3.mp3
+++ b/lua/docs/content/audio/waterdrop_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0979887450dfbac6779484a5c389b6e8fd116eb4e5e9d24fa4c2321698110cb7
-size 4534

--- a/lua/docs/content/audio/waterdrop_4.mp3
+++ b/lua/docs/content/audio/waterdrop_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a81f697f3df93fdc18858de2ebc7ffb4f2d649892c174f707239965e17444fa
-size 4534

--- a/lua/docs/content/audio/whooshes_medium_1.mp3
+++ b/lua/docs/content/audio/whooshes_medium_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e07b6e4ea72fa482a90e54a5dc6269a3fc832f3832279f0742be4bd3665572c
-size 14897

--- a/lua/docs/content/audio/whooshes_medium_2.mp3
+++ b/lua/docs/content/audio/whooshes_medium_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25bca6116efb2bed70e3d91fd4bd52f9a50bffc52a90778cc7df9c053231a211
-size 11445

--- a/lua/docs/content/audio/whooshes_medium_3.mp3
+++ b/lua/docs/content/audio/whooshes_medium_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddecd007f43c8fdc32c7ef365acf5e914d5ad1e1de37697abaaa999628fdc247
-size 9909

--- a/lua/docs/content/audio/whooshes_small_1.mp3
+++ b/lua/docs/content/audio/whooshes_small_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a262e5ae733bda04340be9ade14166e264a9cf03d30e87a3a83f59bec445b25e
-size 7220

--- a/lua/docs/content/audio/whooshes_small_2.mp3
+++ b/lua/docs/content/audio/whooshes_small_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:573b59053e19bf02c5fb9b4aaef78d9c10fed3b886dc1995df5d7d9f282ffcaf
-size 5301

--- a/lua/docs/content/audio/whooshes_small_3.mp3
+++ b/lua/docs/content/audio/whooshes_small_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29318e2019a26bc38df4f0fce2b2d45221b869147929fa8d2f1d8b235f0639d7
-size 11445

--- a/lua/docs/content/audio/whooshes_small_4.mp3
+++ b/lua/docs/content/audio/whooshes_small_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76f2de333d25bb3f89cabbece6dc0dd39ba7fe5f04fc41dd190a4cd35abdae68
-size 8374

--- a/lua/docs/content/audio/wind_wind_child_1.mp3
+++ b/lua/docs/content/audio/wind_wind_child_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af534c39977dcdbe070547b55ea381d94907501556e15403d6ec8b1635c586bc
-size 433457

--- a/lua/docs/content/audio/wood_impact_1.mp3
+++ b/lua/docs/content/audio/wood_impact_1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4309d91bfe7305798149bd4b81732022435240182415424f3a88bd3212c99ded
-size 6449

--- a/lua/docs/content/audio/wood_impact_2.mp3
+++ b/lua/docs/content/audio/wood_impact_2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0f64e1234a95d1fe4937d531e84fdca72d7930badb6b409690d3bebc61cedb9
-size 6453

--- a/lua/docs/content/audio/wood_impact_3.mp3
+++ b/lua/docs/content/audio/wood_impact_3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4adb5bf2f571f14592acac9ed92bfde1dda263178a179dc198f55faf476b348
-size 6453

--- a/lua/docs/content/audio/wood_impact_4.mp3
+++ b/lua/docs/content/audio/wood_impact_4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c1a603f4071716ac1ae0c49917cb2ff6fb1a275d817c209aef4857c7da0bd29
-size 6453

--- a/lua/docs/content/audio/wood_impact_5.mp3
+++ b/lua/docs/content/audio/wood_impact_5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:851f310649a79fbaa03dc6e956770ec0cb4792ef6ce60c955ceacdc14f868923
-size 6454

--- a/lua/docs/content/guides/quick/adding-sounds.yml
+++ b/lua/docs/content/guides/quick/adding-sounds.yml
@@ -1,252 +1,412 @@
-keywords: ["cubzh", "game", "mobile", "scripting", "cube", "voxel", "world", "Minecraft", "Roblox", "code", "documentation", "docs"]
+keywords:
+    [
+        "cubzh",
+        "game",
+        "mobile",
+        "scripting",
+        "cube",
+        "voxel",
+        "world",
+        "Minecraft",
+        "Roblox",
+        "code",
+        "documentation",
+        "docs",
+    ]
 title: "Quick know-how > Adding sounds to your game"
 blocks:
     - text: |
-        Starting from the version 0.0.47, [Cubzh](https://cu.bzh/) has implemented a sound system to help you improve the ambience of your games. You can now pick from a library of built-in musics and sound effects to bring your worlds to life!
+          Starting from the version 0.0.47, [Cubzh](https://cu.bzh/) has implemented a sound system to help you improve the ambience of your games. You can now pick from a library of built-in musics and sound effects to bring your worlds to life!
 
-        In a nutshell, the sound system works as follows:
+          In a nutshell, the sound system works as follows:
 
-        - First, you have to place a listener somewhere in your scene: this is basically a microphone-like object that captures the sounds from all the sources around it and outputs the result to your speakers. It is unique and readily available using the `AudioListener` variable.
-        - Then, to add a new sound source in the game, you have to create a new instance of the `AudioSource` class, assign it a reference to a sound file (among the list of built-in ones, see below) and parent it somewhere in the world's hierarchy.
+          - First, you have to place a listener somewhere in your scene: this is basically a microphone-like object that captures the sounds from all the sources around it and outputs the result to your speakers. It is unique and readily available using the `AudioListener` variable.
+          - Then, to add a new sound source in the game, you have to create a new instance of the `AudioSource` class, assign it a reference to a sound file (among the list of built-in ones, see below) and parent it somewhere in the world's hierarchy.
 
-        All this can be done via a code snippet like this one:
-
-    - code: |
-        Client.OnStart = function()
-            -- add the AudioListener to the player's head
-            -- to "glue the microphone" to this object
-            Player.Head:AddChild(AudioListener)
-
-            -- create a new source
-            as = AudioSource()
-            as.Sound = "death_scream_guy_1"
-            as:SetParent(Player.Head)
-        end
-
-    - text: |
-        You can create as many sources as you want, keeping in mind that one source can only play one sound at a time. And since both the `AudioListener` and `AudioSource` classes inherit from the [`Object`](/reference/object) base, you can set their transform and parent-dependencies like you're used to :)
-
-        Once initialized like this, your `AudioSource` instance can be turned on by calling its `Play` method, and off by calling its `Stop` method:
+          All this can be done via a code snippet like this one:
 
     - code: |
-        gameOver = function()
-            as:Play()
+          Client.OnStart = function()
+              -- add the AudioListener to the player's head
+              -- to "glue the microphone" to this object
+              Player.Head:AddChild(AudioListener)
 
-            Timer(2, false, function()
-                as:Stop()
-            end)
-        end
+              -- create a new source
+              as = AudioSource()
+              as.Sound = "death_scream_guy_1"
+              as:SetParent(Player.Head)
+          end
 
     - text: |
-        The whole trick is then to properly choose your sounds and musics, and to tweak their parameters to better integrate them to the context! Let's see some additional tricks!
+          You can create as many sources as you want, keeping in mind that one source can only play one sound at a time. And since both the `AudioListener` and `AudioSource` classes inherit from the [`Object`](/reference/object) base, you can set their transform and parent-dependencies like you're used to :)
+
+          Once initialized like this, your `AudioSource` instance can be turned on by calling its `Play` method, and off by calling its `Stop` method:
+
+    - code: |
+          gameOver = function()
+              as:Play()
+
+              Timer(2, false, function()
+                  as:Stop()
+              end)
+          end
+
+    - text: |
+          The whole trick is then to properly choose your sounds and musics, and to tweak their parameters to better integrate them to the context! Let's see some additional tricks!
 
     - title: Changing the volume of your AudioSource
 
     - text: |
-        The most commonly used option is the `Volume`. This value goes from 0 (full silence) to 1 (full volume) and makes it easy to level the various sources according to one another.
+          The most commonly used option is the `Volume`. This value goes from 0 (full silence) to 1 (full volume) and makes it easy to level the various sources according to one another.
 
     - code: |
-        as = AudioSource()
-        as.Sound = "gun_shot_1"
-        as:SetParent(gun)
+          as = AudioSource()
+          as.Sound = "gun_shot_1"
+          as:SetParent(gun)
 
-        as.Volume = 0.3
+          as.Volume = 0.3
 
     - title: Taking an excerpt of the sound
 
     - text: |
-        Our most creative contributors have already managed to go above and beyond and make their own sounds by playing around with the existing ones and chopping them up in clever ways! If you too want to try and remix the raw material, have some fun with the `StartAt` and `StopAt` properties of your `AudioSource` (both expressed in milliseconds):
+          Our most creative contributors have already managed to go above and beyond and make their own sounds by playing around with the existing ones and chopping them up in clever ways! If you too want to try and remix the raw material, have some fun with the `StartAt` and `StopAt` properties of your `AudioSource` (both expressed in milliseconds):
 
     - code: |
-        as = AudioSource()
-        as.Sound = "waterdrop_1"
-        as:SetParent(gun)
+          as = AudioSource()
+          as.Sound = "waterdrop_1"
+          as:SetParent(gun)
 
-        as.StartAt = 200
-        as.StopAt = 1000
+          as.StartAt = 200
+          as.StopAt = 1000
 
     - title: Playing around with the pitch
 
     - text: |
-        To expand the audio library, you can also tweak the pitch of the sound file, i.e. how "high" or "low" it is perceived. This property works like this:
+          To expand the audio library, you can also tweak the pitch of the sound file, i.e. how "high" or "low" it is perceived. This property works like this:
 
-        - `1.0` keeps the normal frequency, meaning the sound is as-is
-        - `0.5` halves the frequency, so the audio will sound lower
-        - `2.0` doubles the frequency, so the audio will sound higher
+          - `1.0` keeps the normal frequency, meaning the sound is as-is
+          - `0.5` halves the frequency, so the audio will sound lower
+          - `2.0` doubles the frequency, so the audio will sound higher
 
-        The pitch cannot be 0, but it can technically go up to +infinity. To change it, just set the `Pitch` option of the source:
+          The pitch cannot be 0, but it can technically go up to +infinity. To change it, just set the `Pitch` option of the source:
 
     - code: |
-        as = AudioSource()
-        as.Sound = "waterdrop_1"
-        as:SetParent(gun)
+          as = AudioSource()
+          as.Sound = "waterdrop_1"
+          as:SetParent(gun)
 
-        as.Pitch = 0.5 -- lower the sound
+          as.Pitch = 0.5 -- lower the sound
 
     - title: Tweaking or disabling spatialization
 
     - text: |
-        Another interesting features of the sounds in Cubzh is that, by default, they are spatialized. This means that you won't hear your `AudioSource` the same depending on where the listener is. For example, the sound will be louder when the listener is closer to it, and you will get a left/right pan effect as the angle between the source and the listener changes. This is a great way to make really believable positional sound source in your world in a flash!
+          Another interesting features of the sounds in Cubzh is that, by default, they are spatialized. This means that you won't hear your `AudioSource` the same depending on where the listener is. For example, the sound will be louder when the listener is closer to it, and you will get a left/right pan effect as the angle between the source and the listener changes. This is a great way to make really believable positional sound source in your world in a flash!
 
-        But of course, sometimes, you might want one of your `AudioSource` instances to be just some ambient sound, or a background music. In that case, the sound should not be spatialized, because it is independent of the position of the listener. This is easy to setup: just turn the `Spatialized` property off like this:
+          But of course, sometimes, you might want one of your `AudioSource` instances to be just some ambient sound, or a background music. In that case, the sound should not be spatialized, because it is independent of the position of the listener. This is easy to setup: just turn the `Spatialized` property off like this:
 
     - code: |
-        as = AudioSource()
-        as.Sound = "gun_shot_1"
-        as:SetParent(gun)
+          as = AudioSource()
+          as.Sound = "gun_shot_1"
+          as:SetParent(gun)
 
-        as.Spatialized = False
+          as.Spatialized = False
 
     - text: |
-        If you want to keep the spatialization but customize it in more details, you can force its pan to be more in the left or the right ear using the `Pan` setting.
+          If you want to keep the spatialization but customize it in more details, you can force its pan to be more in the left or the right ear using the `Pan` setting.
 
-        The `Pan` value goes from -1 (left ear only) to 1 (right ear only), with a default of 0 (equal in both ears):
+          The `Pan` value goes from -1 (left ear only) to 1 (right ear only), with a default of 0 (equal in both ears):
 
     - code: |
-        as = AudioSource()
-        as.Sound = "gun_shot_1"
-        as:SetParent(gun)
+          as = AudioSource()
+          as.Sound = "gun_shot_1"
+          as:SetParent(gun)
 
-        as.Pan = -0.5 -- "move the sound" slightly on the left
-    
+          as.Pan = -0.5 -- "move the sound" slightly on the left
+
     - title: List of available sounds
-    
+
     - text: |
-        Here is a list of all the sounds currently available in Cubzh (they should be pretty self-explanatory, but don't hesitate to try out some "surprising" effects to give a unique style to your world!):
-    
+          Here is a list of all the sounds currently available in Cubzh (they should be pretty self-explanatory, but don't hesitate to try out some "surprising" effects to give a unique style to your world!):
+
     - audiolist:
-        - {file: "/audio/440hz.mp3", title: 440hz}
-        - {file: "/audio/big_explosion_1.mp3", title: big_explosion_1}
-        - {file: "/audio/big_explosion_2.mp3", title: big_explosion_2}
-        - {file: "/audio/big_explosion_3.mp3", title: big_explosion_3}
-        - {file: "/audio/broken_glass_1.mp3", title: broken_glass_1}
-        - {file: "/audio/broken_glass_2.mp3", title: broken_glass_2}
-        - {file: "/audio/broken_glass_3.mp3", title: broken_glass_3}
-        - {file: "/audio/broken_glass_4.mp3", title: broken_glass_4}
-        - {file: "/audio/broken_glass_5.mp3", title: broken_glass_5}
-        - {file: "/audio/death_scream_guy_1.mp3", title: death_scream_guy_1}
-        - {file: "/audio/death_scream_guy_2.mp3", title: death_scream_guy_2}
-        - {file: "/audio/death_scream_guy_3.mp3", title: death_scream_guy_3}
-        - {file: "/audio/death_scream_guy_4.mp3", title: death_scream_guy_4}
-        - {file: "/audio/death_scream_guy_5.mp3", title: death_scream_guy_5}
-        - {file: "/audio/death_scream_lady_1.mp3", title: death_scream_lady_1}
-        - {file: "/audio/death_scream_lady_2.mp3", title: death_scream_lady_2}
-        - {file: "/audio/death_scream_lady_3.mp3", title: death_scream_lady_3}
-        - {file: "/audio/death_scream_lady_4.mp3", title: death_scream_lady_4}
-        - {file: "/audio/death_scream_lady_5.mp3", title: death_scream_lady_5}
-        - {file: "/audio/drinking_1.mp3", title: drinking_1}
-        - {file: "/audio/drinking_2.mp3", title: drinking_2}
-        - {file: "/audio/drinking_3.mp3", title: drinking_3}
-        - {file: "/audio/eating_1.mp3", title: eating_1}
-        - {file: "/audio/eating_2.mp3", title: eating_2}
-        - {file: "/audio/eating_3.mp3", title: eating_3}
-        - {file: "/audio/eating_4.mp3", title: eating_4}
-        - {file: "/audio/eating_5.mp3", title: eating_5}
-        - {file: "/audio/fireworks_fireworks — child_1.mp3", title: fireworks_fireworks — child_1}
-        - {file: "/audio/fireworks_fireworks — child_2.mp3", title: fireworks_fireworks — child_2}
-        - {file: "/audio/fireworks_fireworks — child_3.mp3", title: fireworks_fireworks — child_3}
-        - {file: "/audio/ground_digging_1.mp3", title: ground_digging_1}
-        - {file: "/audio/ground_digging_2.mp3", title: ground_digging_2}
-        - {file: "/audio/ground_digging_3.mp3", title: ground_digging_3}
-        - {file: "/audio/gun_reload_1.mp3", title: gun_reload_1}
-        - {file: "/audio/gun_reload_2.mp3", title: gun_reload_2}
-        - {file: "/audio/gun_reload_3.mp3", title: gun_reload_3}
-        - {file: "/audio/gun_shot_1.mp3", title: gun_shot_1}
-        - {file: "/audio/gun_shot_2.mp3", title: gun_shot_2}
-        - {file: "/audio/hurt_scream_female_1.mp3", title: hurt_scream_female_1}
-        - {file: "/audio/hurt_scream_female_2.mp3", title: hurt_scream_female_2}
-        - {file: "/audio/hurt_scream_female_3.mp3", title: hurt_scream_female_3}
-        - {file: "/audio/hurt_scream_female_4.mp3", title: hurt_scream_female_4}
-        - {file: "/audio/hurt_scream_female_5.mp3", title: hurt_scream_female_5}
-        - {file: "/audio/hurt_scream_male_1.mp3", title: hurt_scream_male_1}
-        - {file: "/audio/hurt_scream_male_2.mp3", title: hurt_scream_male_2}
-        - {file: "/audio/hurt_scream_male_3.mp3", title: hurt_scream_male_3}
-        - {file: "/audio/hurt_scream_male_4.mp3", title: hurt_scream_male_4}
-        - {file: "/audio/hurt_scream_male_5.mp3", title: hurt_scream_male_5}
-        - {file: "/audio/laser_gun_shot_1.mp3", title: laser_gun_shot_1}
-        - {file: "/audio/metal_clanging_1.mp3", title: metal_clanging_1}
-        - {file: "/audio/metal_clanging_2.mp3", title: metal_clanging_2}
-        - {file: "/audio/metal_clanging_3.mp3", title: metal_clanging_3}
-        - {file: "/audio/metal_clanging_4.mp3", title: metal_clanging_4}
-        - {file: "/audio/metal_clanging_5.mp3", title: metal_clanging_5}
-        - {file: "/audio/metal_clanging_6.mp3", title: metal_clanging_6}
-        - {file: "/audio/metal_clanging_7.mp3", title: metal_clanging_7}
-        - {file: "/audio/metal_clanging_8.mp3", title: metal_clanging_8}
-        - {file: "/audio/punch_1.mp3", title: punch_1}
-        - {file: "/audio/punch_2.mp3", title: punch_2}
-        - {file: "/audio/rain_1.mp3", title: rain_1}
-        - {file: "/audio/rain_2.mp3", title: rain_2}
-        - {file: "/audio/rain_3.mp3", title: rain_3}
-        - {file: "/audio/river_1.mp3", title: river_1}
-        - {file: "/audio/small_explosion_1.mp3", title: small_explosion_1}
-        - {file: "/audio/small_explosion_2.mp3", title: small_explosion_2}
-        - {file: "/audio/small_explosion_3.mp3", title: small_explosion_3}
-        - {file: "/audio/sword_impact_1.mp3", title: sword_impact_1}
-        - {file: "/audio/sword_impact_2.mp3", title: sword_impact_2}
-        - {file: "/audio/sword_impact_3.mp3", title: sword_impact_3}
-        - {file: "/audio/sword_impact_4.mp3", title: sword_impact_4}
-        - {file: "/audio/sword_impact_5.mp3", title: sword_impact_5}
-        - {file: "/audio/sword_impact_6.mp3", title: sword_impact_6}
-        - {file: "/audio/sword_impact_alt_1.mp3", title: sword_impact_alt_1}
-        - {file: "/audio/sword_impact_alt_2.mp3", title: sword_impact_alt_2}
-        - {file: "/audio/sword_impact_alt_3.mp3", title: sword_impact_alt_3}
-        - {file: "/audio/sword_impact_alt_4.mp3", title: sword_impact_alt_4}
-        - {file: "/audio/sword_impact_alt_5.mp3", title: sword_impact_alt_5}
-        - {file: "/audio/sword_impact_alt_6.mp3", title: sword_impact_alt_6}
-        - {file: "/audio/thunder_1.mp3", title: thunder_1}
-        - {file: "/audio/thunder_2.mp3", title: thunder_2}
-        - {file: "/audio/thunder_3.mp3", title: thunder_3}
-        - {file: "/audio/twang_1.mp3", title: twang_1}
-        - {file: "/audio/twang_2.mp3", title: twang_2}
-        - {file: "/audio/twang_3.mp3", title: twang_3}
-        - {file: "/audio/twang_4.mp3", title: twang_4}
-        - {file: "/audio/walk_concrete_1.mp3", title: walk_concrete_1}
-        - {file: "/audio/walk_concrete_2.mp3", title: walk_concrete_2}
-        - {file: "/audio/walk_concrete_3.mp3", title: walk_concrete_3}
-        - {file: "/audio/walk_concrete_4.mp3", title: walk_concrete_4}
-        - {file: "/audio/walk_concrete_5.mp3", title: walk_concrete_5}
-        - {file: "/audio/walk_grass_1.mp3", title: walk_grass_1}
-        - {file: "/audio/walk_grass_2.mp3", title: walk_grass_2}
-        - {file: "/audio/walk_grass_3.mp3", title: walk_grass_3}
-        - {file: "/audio/walk_grass_4.mp3", title: walk_grass_4}
-        - {file: "/audio/walk_grass_5.mp3", title: walk_grass_5}
-        - {file: "/audio/walk_gravel_1.mp3", title: walk_gravel_1}
-        - {file: "/audio/walk_gravel_2.mp3", title: walk_gravel_2}
-        - {file: "/audio/walk_gravel_3.mp3", title: walk_gravel_3}
-        - {file: "/audio/walk_gravel_4.mp3", title: walk_gravel_4}
-        - {file: "/audio/walk_gravel_5.mp3", title: walk_gravel_5}
-        - {file: "/audio/walk_sand_1.mp3", title: walk_sand_1}
-        - {file: "/audio/walk_sand_2.mp3", title: walk_sand_2}
-        - {file: "/audio/walk_sand_3.mp3", title: walk_sand_3}
-        - {file: "/audio/walk_sand_4.mp3", title: walk_sand_4}
-        - {file: "/audio/walk_sand_5.mp3", title: walk_sand_5}
-        - {file: "/audio/walk_snow_1.mp3", title: walk_snow_1}
-        - {file: "/audio/walk_snow_2.mp3", title: walk_snow_2}
-        - {file: "/audio/walk_snow_3.mp3", title: walk_snow_3}
-        - {file: "/audio/walk_snow_4.mp3", title: walk_snow_4}
-        - {file: "/audio/walk_snow_5.mp3", title: walk_snow_5}
-        - {file: "/audio/walk_wood_1.mp3", title: walk_wood_1}
-        - {file: "/audio/walk_wood_2.mp3", title: walk_wood_2}
-        - {file: "/audio/walk_wood_3.mp3", title: walk_wood_3}
-        - {file: "/audio/walk_wood_4.mp3", title: walk_wood_4}
-        - {file: "/audio/walk_wood_5.mp3", title: walk_wood_5}
-        - {file: "/audio/water_impact_1.mp3", title: water_impact_1}
-        - {file: "/audio/water_impact_2.mp3", title: water_impact_2}
-        - {file: "/audio/water_impact_3.mp3", title: water_impact_3}
-        - {file: "/audio/waterdrop_1.mp3", title: waterdrop_1}
-        - {file: "/audio/waterdrop_2.mp3", title: waterdrop_2}
-        - {file: "/audio/waterdrop_3.mp3", title: waterdrop_3}
-        - {file: "/audio/waterdrop_4.mp3", title: waterdrop_4}
-        - {file: "/audio/whooshes_medium_1.mp3", title: whooshes_medium_1}
-        - {file: "/audio/whooshes_medium_2.mp3", title: whooshes_medium_2}
-        - {file: "/audio/whooshes_medium_3.mp3", title: whooshes_medium_3}
-        - {file: "/audio/whooshes_small_1.mp3", title: whooshes_small_1}
-        - {file: "/audio/whooshes_small_2.mp3", title: whooshes_small_2}
-        - {file: "/audio/whooshes_small_3.mp3", title: whooshes_small_3}
-        - {file: "/audio/whooshes_small_4.mp3", title: whooshes_small_4}
-        - {file: "/audio/wind_wind_child_1.mp3", title: wind_wind_child_1}
-        - {file: "/audio/wood_impact_1.mp3", title: wood_impact_1}
-        - {file: "/audio/wood_impact_2.mp3", title: wood_impact_2}
-        - {file: "/audio/wood_impact_3.mp3", title: wood_impact_3}
-        - {file: "/audio/wood_impact_4.mp3", title: wood_impact_4}
-        - {file: "/audio/wood_impact_5.mp3", title: wood_impact_5}
+          - { file: "/audio/440hz.mp3", title: 440hz }
+          - { file: "/audio/automaticdoor_1.mp3", title: automaticdoor_1 }
+          - { file: "/audio/big_explosion_1.mp3", title: big_explosion_1 }
+          - { file: "/audio/big_explosion_2.mp3", title: big_explosion_2 }
+          - { file: "/audio/big_explosion_3.mp3", title: big_explosion_3 }
+          - { file: "/audio/birdstweeting_1.mp3", title: birdstweeting_1 }
+          - { file: "/audio/bookpageturning_1.mp3", title: bookpageturning_1 }
+          - { file: "/audio/broken_glass_1.mp3", title: broken_glass_1 }
+          - { file: "/audio/broken_glass_2.mp3", title: broken_glass_2 }
+          - { file: "/audio/broken_glass_3.mp3", title: broken_glass_3 }
+          - { file: "/audio/broken_glass_4.mp3", title: broken_glass_4 }
+          - { file: "/audio/broken_glass_5.mp3", title: broken_glass_5 }
+          - { file: "/audio/button_1.mp3", title: button_1 }
+          - { file: "/audio/button_2.mp3", title: button_2 }
+          - { file: "/audio/button_3.mp3", title: button_3 }
+          - { file: "/audio/button_4.mp3", title: button_4 }
+          - { file: "/audio/button_5.mp3", title: button_5 }
+          - { file: "/audio/buttonnegative_1.mp3", title: buttonnegative_1 }
+          - { file: "/audio/buttonnegative_2.mp3", title: buttonnegative_2 }
+          - { file: "/audio/buttonnegative_3.mp3", title: buttonnegative_3 }
+          - { file: "/audio/buttonpositive_1.mp3", title: buttonpositive_1 }
+          - { file: "/audio/buttonpositive_2.mp3", title: buttonpositive_2 }
+          - { file: "/audio/buttonpositive_3.mp3", title: buttonpositive_3 }
+          - { file: "/audio/carengine_1.mp3", title: carengine_1 }
+          - { file: "/audio/carengine_2.mp3", title: carengine_2 }
+          - { file: "/audio/carengine_3.mp3", title: carengine_3 }
+          - { file: "/audio/carhonk_1.mp3", title: carhonk_1 }
+          - { file: "/audio/carstarting_1.mp3", title: carstarting_1 }
+          - { file: "/audio/catmeow_1.mp3", title: catmeow_1 }
+          - { file: "/audio/catmeow_2.mp3", title: catmeow_2 }
+          - { file: "/audio/catmeow_3.mp3", title: catmeow_3 }
+          - { file: "/audio/coin_1.mp3", title: coin_1 }
+          - { file: "/audio/cow_1.mp3", title: cow_1 }
+          - { file: "/audio/cow_2.mp3", title: cow_2 }
+          - { file: "/audio/cow_3.mp3", title: cow_3 }
+          - { file: "/audio/crowd_1.mp3", title: crowd_1 }
+          - { file: "/audio/crowd_2.mp3", title: crowd_2 }
+          - { file: "/audio/crowdapplause_1.mp3", title: crowdapplause_1 }
+          - { file: "/audio/crowdbooing_1.mp3", title: crowdbooing_1 }
+          - { file: "/audio/crowdlaughing_1.mp3", title: crowdlaughing_1 }
+          - { file: "/audio/death_scream_guy_1.mp3", title: death_scream_guy_1 }
+          - { file: "/audio/death_scream_guy_2.mp3", title: death_scream_guy_2 }
+          - { file: "/audio/death_scream_guy_3.mp3", title: death_scream_guy_3 }
+          - { file: "/audio/death_scream_guy_4.mp3", title: death_scream_guy_4 }
+          - { file: "/audio/death_scream_guy_5.mp3", title: death_scream_guy_5 }
+          - {
+                file: "/audio/death_scream_lady_1.mp3",
+                title: death_scream_lady_1,
+            }
+          - {
+                file: "/audio/death_scream_lady_2.mp3",
+                title: death_scream_lady_2,
+            }
+          - {
+                file: "/audio/death_scream_lady_3.mp3",
+                title: death_scream_lady_3,
+            }
+          - {
+                file: "/audio/death_scream_lady_4.mp3",
+                title: death_scream_lady_4,
+            }
+          - {
+                file: "/audio/death_scream_lady_5.mp3",
+                title: death_scream_lady_5,
+            }
+          - { file: "/audio/deathscream_1.mp3", title: deathscream_1 }
+          - { file: "/audio/deathscream_2.mp3", title: deathscream_2 }
+          - { file: "/audio/deathscream_3.mp3", title: deathscream_3 }
+          - { file: "/audio/dogbark_1.mp3", title: dogbark_1 }
+          - { file: "/audio/dogbark_2.mp3", title: dogbark_2 }
+          - { file: "/audio/dogbark_3.mp3", title: dogbark_3 }
+          - { file: "/audio/doorbell_1.mp3", title: doorbell_1 }
+          - { file: "/audio/doorbell_2.mp3", title: doorbell_2 }
+          - { file: "/audio/doorclose_1.mp3", title: doorclose_1 }
+          - { file: "/audio/doorclose_2.mp3", title: doorclose_2 }
+          - { file: "/audio/doorclose_3.mp3", title: doorclose_3 }
+          - { file: "/audio/dooropen_1.mp3", title: dooropen_1 }
+          - { file: "/audio/dooropen_2.mp3", title: dooropen_2 }
+          - { file: "/audio/dooropen_3.mp3", title: dooropen_3 }
+          - { file: "/audio/drinking_1.mp3", title: drinking_1 }
+          - { file: "/audio/drinking_2.mp3", title: drinking_2 }
+          - { file: "/audio/drinking_3.mp3", title: drinking_3 }
+          - { file: "/audio/drumkick_1.mp3", title: drumkick_1 }
+          - { file: "/audio/drumsnare_1.mp3", title: drumsnare_1 }
+          - { file: "/audio/drumtom_1.mp3", title: drumtom_1 }
+          - { file: "/audio/eating_1.mp3", title: eating_1 }
+          - { file: "/audio/eating_2.mp3", title: eating_2 }
+          - { file: "/audio/eating_3.mp3", title: eating_3 }
+          - { file: "/audio/eating_4.mp3", title: eating_4 }
+          - { file: "/audio/eating_5.mp3", title: eating_5 }
+          - { file: "/audio/fire_1.mp3", title: fire_1 }
+          - { file: "/audio/fire_2.mp3", title: fire_2 }
+          - { file: "/audio/fire_3.mp3", title: fire_3 }
+          - { file: "/audio/firecamp_1.mp3", title: firecamp_1 }
+          - {
+                file: "/audio/fireworks_fireworks_child_1.mp3",
+                title: fireworks_fireworks_child_1,
+            }
+          - {
+                file: "/audio/fireworks_fireworks_child_2.mp3",
+                title: fireworks_fireworks_child_2,
+            }
+          - {
+                file: "/audio/fireworks_fireworks_child_3.mp3",
+                title: fireworks_fireworks_child_3,
+            }
+          - { file: "/audio/fryingpane_1.mp3", title: fryingpane_1 }
+          - { file: "/audio/ground_digging_1.mp3", title: ground_digging_1 }
+          - { file: "/audio/ground_digging_2.mp3", title: ground_digging_2 }
+          - { file: "/audio/ground_digging_3.mp3", title: ground_digging_3 }
+          - { file: "/audio/gun_reload_1.mp3", title: gun_reload_1 }
+          - { file: "/audio/gun_reload_2.mp3", title: gun_reload_2 }
+          - { file: "/audio/gun_reload_3.mp3", title: gun_reload_3 }
+          - { file: "/audio/gun_shot_1.mp3", title: gun_shot_1 }
+          - { file: "/audio/gun_shot_2.mp3", title: gun_shot_2 }
+          - { file: "/audio/gunshot_1.mp3", title: gunshot_1 }
+          - { file: "/audio/gunshot_2.mp3", title: gunshot_2 }
+          - { file: "/audio/gunshot_3.mp3", title: gunshot_3 }
+          - { file: "/audio/gunshot_4.mp3", title: gunshot_4 }
+          - { file: "/audio/gunshot_5.mp3", title: gunshot_5 }
+          - { file: "/audio/hitmarker_1.mp3", title: hitmarker_1 }
+          - { file: "/audio/hitmarker_2.mp3", title: hitmarker_2 }
+          - { file: "/audio/hitmarker_3.mp3", title: hitmarker_3 }
+          - { file: "/audio/hitmarker_4.mp3", title: hitmarker_4 }
+          - { file: "/audio/hitmarker_5.mp3", title: hitmarker_5 }
+          - {
+                file: "/audio/hurt_scream_female_1.mp3",
+                title: hurt_scream_female_1,
+            }
+          - {
+                file: "/audio/hurt_scream_female_2.mp3",
+                title: hurt_scream_female_2,
+            }
+          - {
+                file: "/audio/hurt_scream_female_3.mp3",
+                title: hurt_scream_female_3,
+            }
+          - {
+                file: "/audio/hurt_scream_female_4.mp3",
+                title: hurt_scream_female_4,
+            }
+          - {
+                file: "/audio/hurt_scream_female_5.mp3",
+                title: hurt_scream_female_5,
+            }
+          - { file: "/audio/hurt_scream_male_1.mp3", title: hurt_scream_male_1 }
+          - { file: "/audio/hurt_scream_male_2.mp3", title: hurt_scream_male_2 }
+          - { file: "/audio/hurt_scream_male_3.mp3", title: hurt_scream_male_3 }
+          - { file: "/audio/hurt_scream_male_4.mp3", title: hurt_scream_male_4 }
+          - { file: "/audio/hurt_scream_male_5.mp3", title: hurt_scream_male_5 }
+          - { file: "/audio/hurtscream_1.mp3", title: hurtscream_1 }
+          - { file: "/audio/hurtscream_2.mp3", title: hurtscream_2 }
+          - { file: "/audio/hurtscream_3.mp3", title: hurtscream_3 }
+          - { file: "/audio/keydown_1.mp3", title: keydown_1 }
+          - { file: "/audio/keydown_2.mp3", title: keydown_2 }
+          - { file: "/audio/keydown_3.mp3", title: keydown_3 }
+          - { file: "/audio/keydown_4.mp3", title: keydown_4 }
+          - { file: "/audio/keydown_5.mp3", title: keydown_5 }
+          - { file: "/audio/keydown_6.mp3", title: keydown_6 }
+          - { file: "/audio/keydown_7.mp3", title: keydown_7 }
+          - { file: "/audio/laser_gun_shot_1.mp3", title: laser_gun_shot_1 }
+          - { file: "/audio/metal_clanging_1.mp3", title: metal_clanging_1 }
+          - { file: "/audio/metal_clanging_2.mp3", title: metal_clanging_2 }
+          - { file: "/audio/metal_clanging_3.mp3", title: metal_clanging_3 }
+          - { file: "/audio/metal_clanging_4.mp3", title: metal_clanging_4 }
+          - { file: "/audio/metal_clanging_5.mp3", title: metal_clanging_5 }
+          - { file: "/audio/metal_clanging_6.mp3", title: metal_clanging_6 }
+          - { file: "/audio/metal_clanging_7.mp3", title: metal_clanging_7 }
+          - { file: "/audio/metal_clanging_8.mp3", title: metal_clanging_8 }
+          - { file: "/audio/modal_1.mp3", title: modal_1 }
+          - { file: "/audio/modal_2.mp3", title: modal_2 }
+          - { file: "/audio/modal_3.mp3", title: modal_3 }
+          - { file: "/audio/owl_1.mp3", title: owl_1 }
+          - { file: "/audio/owl_2.mp3", title: owl_2 }
+          - { file: "/audio/owl_3.mp3", title: owl_3 }
+          - { file: "/audio/pencilwriting_1.mp3", title: pencilwriting_1 }
+          - { file: "/audio/pencilwriting_2.mp3", title: pencilwriting_2 }
+          - { file: "/audio/pencilwriting_3.mp3", title: pencilwriting_3 }
+          - { file: "/audio/phonecall_1.mp3", title: phonecall_1 }
+          - { file: "/audio/phonecall_2.mp3", title: phonecall_2 }
+          - { file: "/audio/phonecall_3.mp3", title: phonecall_3 }
+          - { file: "/audio/piano_attack.mp3", title: piano_attack }
+          - { file: "/audio/piano_sustain.mp3", title: piano_sustain }
+          - { file: "/audio/predatorgrowl_1.mp3", title: predatorgrowl_1 }
+          - { file: "/audio/predatorgrowl_2.mp3", title: predatorgrowl_2 }
+          - { file: "/audio/predatorgrowl_3.mp3", title: predatorgrowl_3 }
+          - { file: "/audio/punch_1.mp3", title: punch_1 }
+          - { file: "/audio/punch_2.mp3", title: punch_2 }
+          - { file: "/audio/rain_1.mp3", title: rain_1 }
+          - { file: "/audio/rain_2.mp3", title: rain_2 }
+          - { file: "/audio/rain_3.mp3", title: rain_3 }
+          - { file: "/audio/river_1.mp3", title: river_1 }
+          - { file: "/audio/rocketexhaust_1.mp3", title: rocketexhaust_1 }
+          - { file: "/audio/small_explosion_1.mp3", title: small_explosion_1 }
+          - { file: "/audio/small_explosion_2.mp3", title: small_explosion_2 }
+          - { file: "/audio/small_explosion_3.mp3", title: small_explosion_3 }
+          - { file: "/audio/sword_impact_1.mp3", title: sword_impact_1 }
+          - { file: "/audio/sword_impact_10.mp3", title: sword_impact_10 }
+          - { file: "/audio/sword_impact_11.mp3", title: sword_impact_11 }
+          - { file: "/audio/sword_impact_12.mp3", title: sword_impact_12 }
+          - { file: "/audio/sword_impact_2.mp3", title: sword_impact_2 }
+          - { file: "/audio/sword_impact_3.mp3", title: sword_impact_3 }
+          - { file: "/audio/sword_impact_4.mp3", title: sword_impact_4 }
+          - { file: "/audio/sword_impact_5.mp3", title: sword_impact_5 }
+          - { file: "/audio/sword_impact_6.mp3", title: sword_impact_6 }
+          - { file: "/audio/sword_impact_7.mp3", title: sword_impact_7 }
+          - { file: "/audio/sword_impact_8.mp3", title: sword_impact_8 }
+          - { file: "/audio/sword_impact_9.mp3", title: sword_impact_9 }
+          - { file: "/audio/thunder_1.mp3", title: thunder_1 }
+          - { file: "/audio/thunder_2.mp3", title: thunder_2 }
+          - { file: "/audio/thunder_3.mp3", title: thunder_3 }
+          - { file: "/audio/twang_1.mp3", title: twang_1 }
+          - { file: "/audio/twang_2.mp3", title: twang_2 }
+          - { file: "/audio/twang_3.mp3", title: twang_3 }
+          - { file: "/audio/twang_4.mp3", title: twang_4 }
+          - {
+                file: "/audio/underwaterbubbles_1.mp3",
+                title: underwaterbubbles_1,
+            }
+          - {
+                file: "/audio/underwaterbubbles_amb_1.mp3",
+                title: underwaterbubbles_amb_1,
+            }
+          - { file: "/audio/victory_1.mp3", title: victory_1 }
+          - { file: "/audio/walk_concrete_1.mp3", title: walk_concrete_1 }
+          - { file: "/audio/walk_concrete_2.mp3", title: walk_concrete_2 }
+          - { file: "/audio/walk_concrete_3.mp3", title: walk_concrete_3 }
+          - { file: "/audio/walk_concrete_4.mp3", title: walk_concrete_4 }
+          - { file: "/audio/walk_concrete_5.mp3", title: walk_concrete_5 }
+          - { file: "/audio/walk_grass_1.mp3", title: walk_grass_1 }
+          - { file: "/audio/walk_grass_2.mp3", title: walk_grass_2 }
+          - { file: "/audio/walk_grass_3.mp3", title: walk_grass_3 }
+          - { file: "/audio/walk_grass_4.mp3", title: walk_grass_4 }
+          - { file: "/audio/walk_grass_5.mp3", title: walk_grass_5 }
+          - { file: "/audio/walk_gravel_1.mp3", title: walk_gravel_1 }
+          - { file: "/audio/walk_gravel_2.mp3", title: walk_gravel_2 }
+          - { file: "/audio/walk_gravel_3.mp3", title: walk_gravel_3 }
+          - { file: "/audio/walk_gravel_4.mp3", title: walk_gravel_4 }
+          - { file: "/audio/walk_gravel_5.mp3", title: walk_gravel_5 }
+          - { file: "/audio/walk_sand_1.mp3", title: walk_sand_1 }
+          - { file: "/audio/walk_sand_2.mp3", title: walk_sand_2 }
+          - { file: "/audio/walk_sand_3.mp3", title: walk_sand_3 }
+          - { file: "/audio/walk_sand_4.mp3", title: walk_sand_4 }
+          - { file: "/audio/walk_sand_5.mp3", title: walk_sand_5 }
+          - { file: "/audio/walk_snow_1.mp3", title: walk_snow_1 }
+          - { file: "/audio/walk_snow_2.mp3", title: walk_snow_2 }
+          - { file: "/audio/walk_snow_3.mp3", title: walk_snow_3 }
+          - { file: "/audio/walk_snow_4.mp3", title: walk_snow_4 }
+          - { file: "/audio/walk_snow_5.mp3", title: walk_snow_5 }
+          - { file: "/audio/walk_wood_1.mp3", title: walk_wood_1 }
+          - { file: "/audio/walk_wood_2.mp3", title: walk_wood_2 }
+          - { file: "/audio/walk_wood_3.mp3", title: walk_wood_3 }
+          - { file: "/audio/walk_wood_4.mp3", title: walk_wood_4 }
+          - { file: "/audio/walk_wood_5.mp3", title: walk_wood_5 }
+          - { file: "/audio/walksnow_1.mp3", title: walksnow_1 }
+          - { file: "/audio/walksnow_2.mp3", title: walksnow_2 }
+          - { file: "/audio/walksnow_3.mp3", title: walksnow_3 }
+          - { file: "/audio/walksnow_4.mp3", title: walksnow_4 }
+          - { file: "/audio/water_impact_1.mp3", title: water_impact_1 }
+          - { file: "/audio/water_impact_2.mp3", title: water_impact_2 }
+          - { file: "/audio/water_impact_3.mp3", title: water_impact_3 }
+          - { file: "/audio/waterdrop_1.mp3", title: waterdrop_1 }
+          - { file: "/audio/waterdrop_2.mp3", title: waterdrop_2 }
+          - { file: "/audio/waterdrop_3.mp3", title: waterdrop_3 }
+          - { file: "/audio/waterdrop_4.mp3", title: waterdrop_4 }
+          - { file: "/audio/whooshes_medium_1.mp3", title: whooshes_medium_1 }
+          - { file: "/audio/whooshes_medium_2.mp3", title: whooshes_medium_2 }
+          - { file: "/audio/whooshes_medium_3.mp3", title: whooshes_medium_3 }
+          - { file: "/audio/whooshes_small_1.mp3", title: whooshes_small_1 }
+          - { file: "/audio/whooshes_small_2.mp3", title: whooshes_small_2 }
+          - { file: "/audio/whooshes_small_3.mp3", title: whooshes_small_3 }
+          - { file: "/audio/whooshes_small_4.mp3", title: whooshes_small_4 }
+          - { file: "/audio/wind_wind_child_1.mp3", title: wind_wind_child_1 }
+          - { file: "/audio/wood_impact_1.mp3", title: wood_impact_1 }
+          - { file: "/audio/wood_impact_2.mp3", title: wood_impact_2 }
+          - { file: "/audio/wood_impact_3.mp3", title: wood_impact_3 }
+          - { file: "/audio/wood_impact_4.mp3", title: wood_impact_4 }
+          - { file: "/audio/wood_impact_5.mp3", title: wood_impact_5 }
+          - { file: "/audio/zombiegrowl_1.mp3", title: zombiegrowl_1 }
+          - { file: "/audio/zombiegrowl_2.mp3", title: zombiegrowl_2 }
+          - { file: "/audio/zombiegrowl_3.mp3", title: zombiegrowl_3 }

--- a/lua/docs/content/templates/page.tmpl
+++ b/lua/docs/content/templates/page.tmpl
@@ -53,7 +53,9 @@
 						{{ else if .AudioList }}
 							{{ range .AudioList }}
 								<div class="audioPlayer">
-									<audio controls src="{{ .file }}"></audio>
+									<audio controls src="{{ .file }}">
+										<source src="{{ .file }}" type="audio/ogg" />
+									</audio>
 									{{ .title }}
 								</div>
 							{{ end }}
@@ -178,16 +180,16 @@
 					{{ end }}
 				{{ end }}
 
-				{{ if or .Functions .BaseFunctions}} 
+				{{ if or .Functions .BaseFunctions}}
 				<h2><a id="functions" href="#functions">Functions</a></h2>
-					
+
 					{{ range $index, $function := .Functions }}
 						{{ if not $function.Hide }}
 							<a id="functions-{{ GetAnchorLink .Name }}"></a>
 							<div class="object-element-tbl">
 								<div class="object-element-header">
-									{{ if .ArgumentSets}} 
-										<!-- display several lines for function prototype 
+									{{ if .ArgumentSets}}
+										<!-- display several lines for function prototype
 											when different sets of arguments are accepted. -->
 										{{ range $index, $arguments := .ArgumentSets }}<!--
 											--><div class="set-of-arguments"><!--
@@ -288,8 +290,8 @@
 								<a id="functions-{{ GetAnchorLink .Name }}"></a>
 								<div class="object-element-tbl">
 									<div class="object-element-header">
-										{{ if .ArgumentSets}} 
-											<!-- display several lines for function prototype 
+										{{ if .ArgumentSets}}
+											<!-- display several lines for function prototype
 												when different sets of arguments are accepted. -->
 											{{ range $index, $arguments := .ArgumentSets }}<!--
 												--><div class="set-of-arguments"><!--

--- a/lua/docs/docker-compose-dev.yml
+++ b/lua/docs/docker-compose-dev.yml
@@ -1,13 +1,25 @@
-version: '3.1'
+version: "3.1"
 services:
-  lua-docs:
-    build:
-      target: build-env
-    ports:
-      - 80
-    volumes:
-      - ./content:/www
-      - ./parser:/parser
-      - ../modules:/modules
-      - ./webserver:/webserver
-      
+    lua-docs:
+        build:
+            target: build-env
+        ports:
+            - 80
+        volumes:
+            - ./parser:/parser
+            - ../modules:/modules
+            - ./webserver:/webserver
+            # We mount /content into /www (except for the "audio" directory)
+            # - ./content:/www
+            - ./content/404.yml:/www/404.yml
+            - ./content/cubzh-file-format.md:/www/cubzh-file-format.md
+            - ./content/cubzhcheatsheet.yml:/www/cubzhcheatsheet.yml
+            - ./content/guides:/www/guides
+            - ./content/images:/www/images
+            - ./content/index.yml:/www/index.yml
+            - ./content/js:/www/js
+            - ./content/media:/www/media
+            - ./content/modules:/www/modules
+            - ./content/reference:/www/reference
+            - ./content/style:/www/style
+            - ./content/templates:/www/templates

--- a/lua/docs/docker-compose-run.yml
+++ b/lua/docs/docker-compose-run.yml
@@ -1,9 +1,22 @@
-version: '3.1'
+version: "3.1"
 services:
-  lua-docs:
-    build:
-      target: website-dev
-    ports:
-      - 80
-    volumes:
-      - ./content:/www
+    lua-docs:
+        build:
+            target: website-dev
+        ports:
+            - 80
+        volumes:
+            # We mount /content into /www (except for the "audio" directory)
+            # - ./content:/www
+            - ./content/404.yml:/www/404.yml
+            - ./content/cubzh-file-format.md:/www/cubzh-file-format.md
+            - ./content/cubzhcheatsheet.yml:/www/cubzhcheatsheet.yml
+            - ./content/guides:/www/guides
+            - ./content/images:/www/images
+            - ./content/index.yml:/www/index.yml
+            - ./content/js:/www/js
+            - ./content/media:/www/media
+            - ./content/modules:/www/modules
+            - ./content/reference:/www/reference
+            - ./content/style:/www/style
+            - ./content/templates:/www/templates


### PR DESCRIPTION
Update the adding-sounds page with the new sounds available in bundle/audio.

I took the opportunity to convert everything to ogg, but we should either create a symlink or copy the bundle folder into the Docker container to avoid duplication

Fixes [#687](https://github.com/cubzh/cubzh/issues/687) 