### PR TITLE
CI/CD : update Lua docs deploy

### DIFF
--- a/.github/workflows/lua_docs_deploy_prod.yml
+++ b/.github/workflows/lua_docs_deploy_prod.yml
@@ -1,42 +1,41 @@
 name: Deploy to production
 
 on:
-  push:
-    branches: 
-      - main
+    push:
+        branches:
+            - main
 
 jobs:
+    # Deploy Lua documentation
+    # --------------------------------------------------
+    deploy_lua_docs:
+        name: Deploy Lua documentation
+        runs-on: ubuntu-latest
+        steps:
+            - name: Git checkout
+              uses: actions/checkout@v3
+              with:
+                  lfs: "true"
 
-  # Deploy Lua documentation
-  # -------------------------------------------------- 
-  deploy_lua_docs:
-    name: Deploy Lua documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: 'true'
+            - name: Setup Go
+              uses: actions/setup-go@v3
+              with:
+                  go-version: ">=1.23"
+                  cache: true
+                  cache-dependency-path: ./ci/lua_docs_deploy_prod/go.sum
 
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.21'
-          cache: true
-          cache-dependency-path: ./ci/lua_docs_deploy_prod/go.sum
+            - name: Build Dagger program
+              working-directory: ./ci/lua_docs_deploy_prod
+              run: go build -o deploy -v ./...
 
-      - name: Build Dagger program
-        working-directory: ./ci/lua_docs_deploy_prod
-        run: go build -o deploy -v ./...
-
-      - name: Run Dagger program
-        env: # Or as an environment variable
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICI4ZmZmNmZkMi05MDhiLTQ4YTEtOGQ2Zi1iZWEyNGRkNzk4MTkifQ.l1Sf1gB37veXUWhxOgmjvjYcrh32NiuovbMxvjVI7Z0"
-          DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
-          DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
-          LUA_DOCS_DOCKER_IMAGE_NAME: ${{ secrets.LUA_DOCS_DOCKER_IMAGE_NAME }}
-          LUA_DOCS_SRV_SSH_URL: ${{ secrets.LUA_DOCS_SRV_SSH_URL }}
-          LUA_DOCS_SRV_SSH_PRIVATEKEY: ${{ secrets.LUA_DOCS_SRV_SSH_PRIVATEKEY }}
-          LUA_DOCS_SRV_SSH_KNOWNHOSTS: ${{ secrets.LUA_DOCS_SRV_SSH_KNOWNHOSTS }}
-        working-directory: ./ci/lua_docs_deploy_prod
-        run: ./deploy
+            - name: Run Dagger program
+              env: # Or as an environment variable
+                  _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICI4ZmZmNmZkMi05MDhiLTQ4YTEtOGQ2Zi1iZWEyNGRkNzk4MTkifQ.l1Sf1gB37veXUWhxOgmjvjYcrh32NiuovbMxvjVI7Z0"
+                  DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
+                  DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+                  LUA_DOCS_DOCKER_IMAGE_NAME: ${{ secrets.LUA_DOCS_DOCKER_IMAGE_NAME }}
+                  LUA_DOCS_SRV_SSH_URL: ${{ secrets.LUA_DOCS_SRV_SSH_URL }}
+                  LUA_DOCS_SRV_SSH_PRIVATEKEY: ${{ secrets.LUA_DOCS_SRV_SSH_PRIVATEKEY }}
+                  LUA_DOCS_SRV_SSH_KNOWNHOSTS: ${{ secrets.LUA_DOCS_SRV_SSH_KNOWNHOSTS }}
+              working-directory: ./ci/lua_docs_deploy_prod
+              run: ./deploy

--- a/ci/lua_docs_deploy_prod/main.go
+++ b/ci/lua_docs_deploy_prod/main.go
@@ -145,7 +145,10 @@ func deployLuaDocs() error {
 	// get repo root directory
 	// (including only the /lua directory, and excluding everything else)
 	rootDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
-		Include: []string{"./lua"},
+		Include: []string{
+			"./lua",
+			"./bundle/audio",
+		},
 	})
 	if rootDir == nil {
 		return errors.New("root directory not found")


### PR DESCRIPTION
the last PR merge failed to auto-redeploy the Lua docs:

https://github.com/cubzh/cubzh/actions/runs/11427263668/job/31791186822

Because last PR (https://github.com/cubzh/cubzh/pull/689) introduced the use of `./bundle/audio` files in the docs instead of duplicating them in `./lua/docs/content/audio`

This PR fixes the deploy by adding the missing `./bundle/audio` in the docker build context.

### Note

- I already ran the deploy process on my machine to test my fix, so the docs are already up to date here : https://docs.cu.bzh 
- The only change in the YAML file is this line : `go-version: ">=1.23"` & indent size

