### PR TITLE
Fix prints in config.lua

### DIFF
--- a/lua/modules/config.lua
+++ b/lua/modules/config.lua
@@ -6,7 +6,7 @@ defaultOptions = {
 	acceptTypes = {}, -- { fieldName : { "Number3", "Object" }}
 }
 
-config.merge = function(self, defaults, overrides, options)
+config.merge = function(self, defaults, overrides, options, showIgnoring)
 	if self ~= config then
 		error("config:merge should be called with `:`", 2)
 	end
@@ -67,7 +67,7 @@ config.merge = function(self, defaults, overrides, options)
 					end
 				end
 			end
-			if overriden == false then
+			if overriden == false and showIgnoring then
 				print("⚠️ config:merge - overrides key ignored: " .. k)
 			end
 		end


### PR DESCRIPTION
Added `showIgnoring` parameter in config:merge() to prevent printing in chat.
Probably can be done better, but it fixes this issue everywhere.