### PR TITLE
Camera auto width/height explicit flag

### DIFF
--- a/core/camera.h
+++ b/core/camera.h
@@ -48,9 +48,9 @@ void camera_set_mode(Camera *c, const ProjectionMode value);
 float camera_get_fov(const Camera *c);
 void camera_set_fov(Camera *c, const float value);
 float camera_get_width(const Camera *c);
-void camera_set_width(Camera *c, const float value);
+void camera_set_width(Camera *c, const float value, const bool dirty);
 float camera_get_height(const Camera *c);
-void camera_set_height(Camera *c, const float value);
+void camera_set_height(Camera *c, const float value, const bool dirty);
 float camera_get_near(const Camera *c);
 void camera_set_near(Camera *c, const float value);
 float camera_get_far(const Camera *c);
@@ -67,6 +67,10 @@ bool camera_is_view_dirty(const Camera *c);
 bool camera_is_projection_dirty(const Camera *c);
 bool camera_is_target_dirty(const Camera *c);
 void camera_clear_dirty(Camera *c);
+void camera_toggle_auto_projection_width(Camera *c, const bool value);
+bool camera_uses_auto_projection_width(const Camera *c);
+void camera_toggle_auto_projection_height(Camera *c, const bool value);
+bool camera_uses_auto_projection_height(const Camera *c);
 
 // MARK: - View -
 

--- a/core/serialization_gltf.c
+++ b/core/serialization_gltf.c
@@ -552,8 +552,8 @@ bool serialization_gltf_load(const void *buffer, const size_t size, const ASSET_
             switch(node->camera->type) {
                 case cgltf_camera_type_orthographic: {
                     camera_set_mode(c, Orthographic);
-                    camera_set_width(c, node->camera->data.orthographic.xmag);
-                    camera_set_height(c, node->camera->data.orthographic.ymag);
+                    camera_set_width(c, node->camera->data.orthographic.xmag, true);
+                    camera_set_height(c, node->camera->data.orthographic.ymag, true);
                     camera_set_near(c, node->camera->data.orthographic.znear);
                     camera_set_far(c, node->camera->data.orthographic.zfar);
                     break;
@@ -561,8 +561,8 @@ bool serialization_gltf_load(const void *buffer, const size_t size, const ASSET_
                 case cgltf_camera_type_perspective: {
                     camera_set_mode(c, Perspective);
                     if (node->camera->data.perspective.has_aspect_ratio) {
-                        camera_set_width(c, node->camera->data.perspective.aspect_ratio);
-                        camera_set_height(c, 1.0f);
+                        camera_set_width(c, node->camera->data.perspective.aspect_ratio, true);
+                        camera_set_height(c, 1.0f, true);
                     }
                     camera_set_fov(c, node->camera->data.perspective.yfov);
                     if (node->camera->data.perspective.has_zfar) {


### PR DESCRIPTION
Camera projection size can be used internally to store the value itself, or -1 as a flag to indicate to the renderer that it should be updated automatically (this is by default).

As a consequence, Camera.Width/Height would return -1.

This PR ensures that those fields always return a value. When set to be updated automatically, it will return the last value assigned by the renderer.

Note that setting the fields back to -1 to revert to auto-update will still work