### PR TITLE
Fix Android compilation: migrate to AGP 9.0.1

### DIFF
--- a/android-fix-plan.md
+++ b/android-fix-plan.md
@@ -17,8 +17,8 @@ The repository was recently restructured (PR #947 `repo-restructure`), moving th
 
 ## Phase 3: Verification
 
-- [ ] **3a.** Run `cd clients/android && ./gradlew assembleDebug` and confirm the build completes (or identify further C++ issues).
-- [ ] **3b.** Verify APK is generated at `clients/android/app/build/outputs/apk/debug/`.
+- [x] **3a.** Run `cd clients/android && ./gradlew assembleDebug` — initial run revealed CMake path errors: `REPO_ROOT_DIR` in `CMakeLists.txt` and `xptools.cmake` used `CMAKE_CURRENT_BINARY_DIR` which resolved incorrectly after the repo restructure. Fixed both to use `CMAKE_CURRENT_SOURCE_DIR`. Build then completed successfully.
+- [x] **3b.** APK generated at `clients/android/app/build/outputs/apk/debug/app-debug.apk` (~121 MB).
 
 ## Files to Modify
 

--- a/android-fix-plan.md
+++ b/android-fix-plan.md
@@ -4,48 +4,25 @@
 
 The repository was recently restructured (PR #947 `repo-restructure`), moving the Android project from the repo root to `clients/android/`. Several path references in build files were updated in commit `6d7d339d`, but remaining issues prevent successful compilation. The current branch is `fix-android-compilation`.
 
-## Issues Found (in order of build failure)
+## Phase 1: Fix build configuration
 
-### Issue 1: Missing `local.properties` (BLOCKING)
-- **File:** `clients/android/local.properties` (does not exist)
-- **Problem:** The old `local.properties` was at root `/android/local.properties` and didn't get carried over. Without it, Gradle can't find the Android SDK.
-- **Fix:** Create `clients/android/local.properties` with `sdk.dir=/Users/gaetan/Library/Android/sdk`
-- **Note:** This file is gitignored and per-developer, so it just needs to exist locally.
+- [x] **1a.** Create `clients/android/local.properties` with `sdk.dir` — already exists locally.
+- [x] **1b.** Copy `google-services.json.template` → `google-services.json` in `clients/android/app/` (gitignored, local dev placeholder).
+- [x] **1c.** Fix `.env` path in `clients/android/app/build.gradle` line 16: `../.env` → `../../.env`.
+- [x] **1d.** Fix keystore paths in `clients/android/app/build.gradle` lines 31, 37: replaced Windows backslash separators with forward slashes.
 
-### Issue 2: Missing `google-services.json` (BLOCKING)
-- **File:** `clients/android/app/google-services.json` (does not exist, only `.template`)
-- **Problem:** The `com.google.gms.google-services` Gradle plugin fails if this file is missing. The real file contains Firebase project credentials and is not committed to the repo.
-- **Fix:** Copy the template as a placeholder for local dev builds: `cp google-services.json.template google-services.json` in `clients/android/app/`. For production builds, the real credentials file needs to be provided separately.
+## Phase 2: Clean up stale root directory
 
-### Issue 3: `.env` file path is wrong
-- **File:** `clients/android/app/build.gradle` line 16
-- **Current:** `def envFile = rootProject.file("../.env")` → resolves to `clients/.env`
-- **Should be:** `def envFile = rootProject.file("../../.env")` → resolves to repo root `.env`
-- **Impact:** Environment variables (API keys etc.) won't be forwarded to CMake. Build won't fail but the app will lack config values.
+- [ ] **2a.** Delete the root `android/` directory (old build artifacts: `.gradle/`, `.idea/`, `build/` caches).
 
-### Issue 4: Keystore paths use Windows backslash separators
-- **File:** `clients/android/app/build.gradle` lines 31, 37
-- **Current:**
-  - Line 31: `storeFile file('.\\..\\..\\pcubes-keystore.jks')`
-  - Line 37: `storeFile file('.\\..\\voxowl_debug.jks')`
-- **Fix:**
-  - Line 31: `storeFile file('../../pcubes-keystore.jks')`
-  - Line 37: `storeFile file('../voxowl_debug.jks')`
-- **Impact:** Debug/release signing fails on macOS/Linux.
+## Phase 3: Verification
 
-### Issue 5: Stale root `android/` directory
-- **Problem:** Old build artifacts remain at the repo root in an untracked `android/` directory (contains `.gradle/`, `.idea/`, `build/` caches). This is confusing and could mislead IDE project detection.
-- **Fix:** Delete the root `android/` directory.
+- [ ] **3a.** Run `cd clients/android && ./gradlew assembleDebug` and confirm the build completes (or identify further C++ issues).
+- [ ] **3b.** Verify APK is generated at `clients/android/app/build/outputs/apk/debug/`.
 
 ## Files to Modify
 
-1. **`clients/android/local.properties`** — create (not committed, gitignored)
+1. **`clients/android/local.properties`** — create (not committed, gitignored) ✅
 2. **`clients/android/app/google-services.json`** — copy from template (not committed, gitignored)
 3. **`clients/android/app/build.gradle`** — fix `.env` path (line 16) and keystore paths (lines 31, 37)
 4. **Root `android/`** — delete stale directory
-
-## Verification
-
-1. Run `cd clients/android && ./gradlew assembleDebug` and confirm the build completes
-2. If C++ compilation issues surface after the above fixes, address them incrementally
-3. Verify the APK is generated at `clients/android/app/build/outputs/apk/debug/`

--- a/android-fix-plan.md
+++ b/android-fix-plan.md
@@ -13,7 +13,7 @@ The repository was recently restructured (PR #947 `repo-restructure`), moving th
 
 ## Phase 2: Clean up stale root directory
 
-- [ ] **2a.** Delete the root `android/` directory (old build artifacts: `.gradle/`, `.idea/`, `build/` caches).
+- [x] **2a.** Delete the root `android/` directory (old build artifacts: `.gradle/`, `.idea/`, `build/` caches). Removed 936K of stale files.
 
 ## Phase 3: Verification
 

--- a/android-fix-plan.md
+++ b/android-fix-plan.md
@@ -1,0 +1,51 @@
+# Plan: Fix Android Compilation
+
+## Context
+
+The repository was recently restructured (PR #947 `repo-restructure`), moving the Android project from the repo root to `clients/android/`. Several path references in build files were updated in commit `6d7d339d`, but remaining issues prevent successful compilation. The current branch is `fix-android-compilation`.
+
+## Issues Found (in order of build failure)
+
+### Issue 1: Missing `local.properties` (BLOCKING)
+- **File:** `clients/android/local.properties` (does not exist)
+- **Problem:** The old `local.properties` was at root `/android/local.properties` and didn't get carried over. Without it, Gradle can't find the Android SDK.
+- **Fix:** Create `clients/android/local.properties` with `sdk.dir=/Users/gaetan/Library/Android/sdk`
+- **Note:** This file is gitignored and per-developer, so it just needs to exist locally.
+
+### Issue 2: Missing `google-services.json` (BLOCKING)
+- **File:** `clients/android/app/google-services.json` (does not exist, only `.template`)
+- **Problem:** The `com.google.gms.google-services` Gradle plugin fails if this file is missing. The real file contains Firebase project credentials and is not committed to the repo.
+- **Fix:** Copy the template as a placeholder for local dev builds: `cp google-services.json.template google-services.json` in `clients/android/app/`. For production builds, the real credentials file needs to be provided separately.
+
+### Issue 3: `.env` file path is wrong
+- **File:** `clients/android/app/build.gradle` line 16
+- **Current:** `def envFile = rootProject.file("../.env")` → resolves to `clients/.env`
+- **Should be:** `def envFile = rootProject.file("../../.env")` → resolves to repo root `.env`
+- **Impact:** Environment variables (API keys etc.) won't be forwarded to CMake. Build won't fail but the app will lack config values.
+
+### Issue 4: Keystore paths use Windows backslash separators
+- **File:** `clients/android/app/build.gradle` lines 31, 37
+- **Current:**
+  - Line 31: `storeFile file('.\\..\\..\\pcubes-keystore.jks')`
+  - Line 37: `storeFile file('.\\..\\voxowl_debug.jks')`
+- **Fix:**
+  - Line 31: `storeFile file('../../pcubes-keystore.jks')`
+  - Line 37: `storeFile file('../voxowl_debug.jks')`
+- **Impact:** Debug/release signing fails on macOS/Linux.
+
+### Issue 5: Stale root `android/` directory
+- **Problem:** Old build artifacts remain at the repo root in an untracked `android/` directory (contains `.gradle/`, `.idea/`, `build/` caches). This is confusing and could mislead IDE project detection.
+- **Fix:** Delete the root `android/` directory.
+
+## Files to Modify
+
+1. **`clients/android/local.properties`** — create (not committed, gitignored)
+2. **`clients/android/app/google-services.json`** — copy from template (not committed, gitignored)
+3. **`clients/android/app/build.gradle`** — fix `.env` path (line 16) and keystore paths (lines 31, 37)
+4. **Root `android/`** — delete stale directory
+
+## Verification
+
+1. Run `cd clients/android && ./gradlew assembleDebug` and confirm the build completes
+2. If C++ compilation issues surface after the above fixes, address them incrementally
+3. Verify the APK is generated at `clients/android/app/build/outputs/apk/debug/`

--- a/clients/android/.idea/vcs.xml
+++ b/clients/android/.idea/vcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../cubzh" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -2,7 +2,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
     // Add the Google services Gradle plugin
     // Needed for Push Notifications.
     id 'com.google.gms.google-services'
@@ -23,6 +22,24 @@ if (envFile.exists()) {
             env[key.trim()] = value.trim()
         }
     }
+}
+
+// Detect OS (invariant across variants)
+def hostOs = ""
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    hostOs = "windows"
+} else if (Os.isFamily(Os.FAMILY_MAC)) {
+    hostOs = "macos"
+} else if (Os.isFamily(Os.FAMILY_UNIX)) {
+    hostOs = "linux"
+}
+
+// Detect native architecture
+def hostArch = System.getProperty("os.arch")
+if (hostArch == "aarch64") {
+    hostArch = "arm64"
+} else if (hostArch == "amd64") {
+    hostArch = "x86_64"
 }
 
 android {
@@ -57,84 +74,6 @@ android {
                 arguments += env.collect { k, v -> "-DENVVAR_${k}=${v}" }
             }
         }
-    }
-    android.applicationVariants.configureEach { variant ->
-
-        // Detect OS
-        def os = ""
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            os = "windows"
-        } else if (Os.isFamily(Os.FAMILY_MAC)) {
-            os = "macos"
-        } else if (Os.isFamily(Os.FAMILY_UNIX)) {
-            os = "linux"
-        } else {
-            // TODO: abort build process
-        }
-
-        // Detect native architecture
-        def arch = System.getProperty("os.arch")
-        if (arch == "aarch64") {
-            arch = "arm64"
-        } else if (arch == "amd64") {
-            arch = "x86_64"
-        } else {
-            // TODO: abort build process
-        }
-
-        // Make sure dependencies are up to date (deptool)
-
-        def deptoolCommand = ["./deptool_${os}_${arch}", "autoconfig", "android"]
-        if (os == 'windows') {
-            deptoolCommand[0] = "deptool_${os}_${arch}.exe"
-            deptoolCommand = ['cmd', '/c'] + deptoolCommand
-        }
-        def taskDeptoolAutoconfig = project.tasks.create("deptoolAutoconfig_${variant.name}", Exec)
-        taskDeptoolAutoconfig.workingDir("../../../deps/deptool/cmd")
-        taskDeptoolAutoconfig.commandLine(deptoolCommand)
-
-        // Update hashes for Luau modules
-
-        def hashCommand = ["./deps/hasher/${os}/${arch}/hasher"]
-        if (os == 'windows') {
-            hashCommand[0] = "deps\\hasher\\${os}\\${arch}\\hasher.exe"
-            hashCommand = ['cmd', '/c'] + hashCommand
-        }
-        def taskHashLuaModules = project.tasks.create("hashModules_${variant.name}", Exec)
-        taskHashLuaModules.workingDir("../../..")
-        taskHashLuaModules.commandLine(hashCommand)
-
-        // Update asset bundle
-
-        def taskClean = project.tasks.create("cleanAssets_${variant.name}", Delete)
-        taskClean.delete("./src/main/assets")
-
-        def taskCopy = project.tasks.create("copyAssets_${variant.name}", Copy)
-        taskCopy.from("./../../../bundle")
-        taskCopy.into("./src/main/assets")
-        taskCopy.dependsOn taskClean
-
-        def taskCopyI18n = project.tasks.create("copyI18nAssets_${variant.name}", Copy)
-        taskCopyI18n.from("./../../../i18n")
-        taskCopyI18n.into("./src/main/assets/i18n")
-        taskCopyI18n.dependsOn taskCopy
-
-        def taskCopyLuaModules = project.tasks.create("copyAssets_ossLuaModules_${variant.name}", Copy)
-        taskCopyLuaModules.from("./../../../lua/modules")
-        taskCopyLuaModules.into("./src/main/assets/modules")
-        taskCopyLuaModules.dependsOn taskCopyI18n
-
-        def taskShaders = project.tasks.create("cleanShaders_${variant.name}", Delete)
-        taskShaders.delete("./src/main/assets/shaders/dx9")
-        taskShaders.delete("./src/main/assets/shaders/dx11")
-        taskShaders.delete("./src/main/assets/shaders/glsl")
-        taskShaders.delete("./src/main/assets/shaders/metal")
-        taskShaders.dependsOn taskCopyLuaModules
-
-        def provider = variant.getPreBuildProvider()
-        provider.get().dependsOn taskShaders
-        provider.get().dependsOn taskHashLuaModules
-        provider.get().dependsOn(taskDeptoolAutoconfig)
     }
     buildTypes {
         release {
@@ -184,17 +123,82 @@ android {
     buildFeatures {
         buildConfig = true
     }
-    packagingOptions {
+    packaging {
         resources.excludes.add("META-INF/*")
     }
 }
 
-tasks.configureEach { task ->
-    bundleRelease
-    if (task.name == 'bundleRelease') {
-        task.finalizedBy uploadCrashlyticsSymbolFileRelease
-    } else if (task.name == 'assembleRelease') {
-        task.finalizedBy uploadCrashlyticsSymbolFileRelease
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        def variantName = variant.name
+
+        // Make sure dependencies are up to date (deptool)
+        def deptoolCommand = ["./deptool_${hostOs}_${hostArch}", "autoconfig", "android"]
+        if (hostOs == 'windows') {
+            deptoolCommand[0] = "deptool_${hostOs}_${hostArch}.exe"
+            deptoolCommand = ['cmd', '/c'] + deptoolCommand
+        }
+        tasks.register("deptoolAutoconfig_${variantName}", Exec) {
+            workingDir("../../../deps/deptool/cmd")
+            commandLine(deptoolCommand)
+        }
+
+        // Update hashes for Luau modules
+        def hashCommand = ["./deps/hasher/${hostOs}/${hostArch}/hasher"]
+        if (hostOs == 'windows') {
+            hashCommand[0] = "deps\\hasher\\${hostOs}\\${hostArch}\\hasher.exe"
+            hashCommand = ['cmd', '/c'] + hashCommand
+        }
+        tasks.register("hashModules_${variantName}", Exec) {
+            workingDir("../../..")
+            commandLine(hashCommand)
+        }
+
+        // Update asset bundle
+        tasks.register("cleanAssets_${variantName}", Delete) {
+            delete("./src/main/assets")
+        }
+
+        tasks.register("copyAssets_${variantName}", Copy) {
+            from("./../../../bundle")
+            into("./src/main/assets")
+            dependsOn "cleanAssets_${variantName}"
+        }
+
+        tasks.register("copyI18nAssets_${variantName}", Copy) {
+            from("./../../../i18n")
+            into("./src/main/assets/i18n")
+            dependsOn "copyAssets_${variantName}"
+        }
+
+        tasks.register("copyAssets_ossLuaModules_${variantName}", Copy) {
+            from("./../../../lua/modules")
+            into("./src/main/assets/modules")
+            dependsOn "copyI18nAssets_${variantName}"
+        }
+
+        tasks.register("cleanShaders_${variantName}", Delete) {
+            delete("./src/main/assets/shaders/dx9")
+            delete("./src/main/assets/shaders/dx11")
+            delete("./src/main/assets/shaders/glsl")
+            delete("./src/main/assets/shaders/metal")
+            dependsOn "copyAssets_ossLuaModules_${variantName}"
+        }
+
+        // Wire to preBuild (deferred, as preBuild tasks are created later)
+        project.afterEvaluate {
+            tasks.named("pre${variantName.capitalize()}Build").configure {
+                dependsOn "cleanShaders_${variantName}"
+                dependsOn "hashModules_${variantName}"
+                dependsOn "deptoolAutoconfig_${variantName}"
+            }
+        }
+    }
+}
+
+afterEvaluate {
+    tasks.matching { it.name == 'bundleRelease' || it.name == 'assembleRelease' }.configureEach {
+        finalizedBy "uploadCrashlyticsSymbolFileRelease"
     }
 }
 
@@ -223,10 +227,6 @@ dependencies {
 }
 
 // Report use of deprecated APIs
-allprojects {
-    tasks.withType(JavaCompile).tap {
-        configureEach {
-            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-        }
-    }
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 // Parse .env variables (once per gradle sync)
-def envFile = rootProject.file("../.env")
+def envFile = rootProject.file("../../.env")
 def env = [:]
 if (envFile.exists()) {
     envFile.eachLine { line ->
@@ -28,13 +28,13 @@ if (envFile.exists()) {
 android {
     signingConfigs {
         release {
-            storeFile file('.\\..\\..\\pcubes-keystore.jks')
+            storeFile file('../../pcubes-keystore.jks')
             storePassword findProperty("storePassword") // it is in ~/.gradle/gradle.properties
             keyAlias 'release'
             keyPassword findProperty("keyPassword") // it is in ~/.gradle/gradle.properties
         }
         debug {
-            storeFile file('.\\..\\voxowl_debug.jks')
+            storeFile file('../voxowl_debug.jks')
             storePassword 'elleestoulapoulette'
             keyAlias 'debug'
             keyPassword 'elleestoulapoulette'

--- a/clients/android/app/src/main/cpp/CMakeLists.txt
+++ b/clients/android/app/src/main/cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach (v ${vars})
     endif()
 endforeach()
 
-set(REPO_ROOT_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../../../../..")
+set(REPO_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../..")
 
 set(CUBZH_CORE_DIR "${REPO_ROOT_DIR}/core")
 set(COMMON_DIR "${REPO_ROOT_DIR}/common")

--- a/clients/android/app/src/main/cpp/xptools.cmake
+++ b/clients/android/app/src/main/cpp/xptools.cmake
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.20)
 # project(xptools)
 
 #
-set(REPO_ROOT_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../../../../..")
+set(REPO_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../..")
 set(VXTOOLS_DIR "${REPO_ROOT_DIR}/deps/xptools")
 set(VXTOOLS_INCLUDE_DIR "${VXTOOLS_DIR}/include")
 set(VXTOOLS_COMMON_DIR "${VXTOOLS_DIR}/common")

--- a/clients/android/build.gradle
+++ b/clients/android/build.gradle
@@ -2,10 +2,9 @@
 
 plugins {
     // Android
-    id 'com.android.application' version '8.13.0' apply false
-    // Kotlin
-    id 'org.jetbrains.kotlin.android' version '2.1.21' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.1.21'
+    id 'com.android.application' version '9.0.1' apply false
+    // Kotlin serialization
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.20' apply false
     // Add the dependency for the Google services Gradle plugin
     // Needed for Push Notifications.
     id 'com.google.gms.google-services' version '4.4.3' apply false

--- a/clients/android/gradle.properties
+++ b/clients/android/gradle.properties
@@ -14,7 +14,4 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
-android.enableJetifier=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 org.gradle.warning.mode=all

--- a/clients/android/gradle/wrapper/gradle-wrapper.properties
+++ b/clients/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 25 14:56:05 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/deps/gradle.properties
+++ b/deps/gradle.properties
@@ -1,0 +1,11 @@
+android.builtInKotlin=false
+android.defaults.buildfeatures.resvalues=true
+android.dependency.useConstraints=true
+android.enableAppCompileTimeRClass=false
+android.newDsl=false
+android.r8.optimizedResourceShrinking=false
+android.r8.strictFullModeForKeepRules=false
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.uniquePackageNames=false
+android.useAndroidX=false
+android.usesSdkInManifest.disallowed=false


### PR DESCRIPTION
## Summary

- Fix Android build after repo restructure (paths for .env, keystores, CMake `REPO_ROOT_DIR`)
- Delete stale root `android/` directory left over from restructure
- Migrate from AGP 8.13.0 to AGP 9.0.1 and Gradle 8.13 to 9.2.1
- Replace legacy `applicationVariants` API with `androidComponents.onVariants` and lazy task registration
- Remove `org.jetbrains.kotlin.android` plugin (built into AGP 9)
- Clean up deprecated Gradle properties and API usage (`packagingOptions` → `packaging`, `allprojects` block, eager task resolution)

## Test plan

- [x] `./gradlew assembleDebug` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)